### PR TITLE
Fix return type of GTM predict function

### DIFF
--- a/lib/model/gtm.js
+++ b/lib/model/gtm.js
@@ -173,7 +173,7 @@ export default class GTM {
 	 * Returns predicted values.
 	 *
 	 * @param {Array<Array<number>>} x Sample data
-	 * @returns {number[]} Predicted values
+	 * @returns {Array<Array<number>>} Predicted values
 	 */
 	predict(x) {
 		const r = this.responsibility(x)


### PR DESCRIPTION
Resolve #176 .

Changes proposed in this pull request:
- Fix return type of GTM predict function

