### PR TITLE
Fix return type of the Mean shift fit function

### DIFF
--- a/lib/model/mean_shift.js
+++ b/lib/model/mean_shift.js
@@ -108,7 +108,7 @@ export default class MeanShift {
 			let oldPoint = c
 			const v = fd(c)
 			const newPoint = c.map((a, i) => a + v[i])
-			isChanged |= oldPoint.some((v, i) => v !== newPoint[i])
+			isChanged ||= oldPoint.some((v, i) => v !== newPoint[i])
 			return newPoint
 		})
 


### PR DESCRIPTION
Resolve #358 .

Changes proposed in this pull request:
- Fix return type of the Mean shift fit function
