### PR TITLE
Improve graph

### DIFF
--- a/lib/util/graph.js
+++ b/lib/util/graph.js
@@ -33,6 +33,14 @@ export class Edge {
 		this.weighted = value != null
 	}
 
+	get from() {
+		return this[0]
+	}
+
+	get to() {
+		return this[1]
+	}
+
 	get value0() {
 		return this.weighted ? this.value : null
 	}
@@ -44,7 +52,7 @@ export class Edge {
 export default class Graph {
 	/**
 	 * @param {number | unknown[]} [nodes=0] Number of nodes or values of nodes
-	 * @param {([number, number] | Edge)[]} [edges=[]] Edges
+	 * @param {([number, number] | {0?: number, 1?: number, from?: number, to?: number, value?: unknown, direct?: boolean} | Edge)[]} [edges=[]] Edges
 	 */
 	constructor(nodes = 0, edges = []) {
 		if (Array.isArray(nodes)) {
@@ -52,7 +60,9 @@ export default class Graph {
 		} else {
 			this._nodes = Array(nodes)
 		}
-		this._edges = edges.map(e => new Edge(e[0], e[1], e instanceof Edge ? e.value0 : e.value, e.direct))
+		this._edges = edges.map(
+			e => new Edge(e[0] | e.from, e[1] | e.to, e instanceof Edge ? e.value0 : e.value, e.direct)
+		)
 	}
 
 	/**
@@ -1031,29 +1041,19 @@ export default class Graph {
 			direct = undirect
 			undirect = false
 		}
-		const nodes = []
-		const cons = Array(this._nodes.length).fill(false)
+		const nodesSet = new Set()
 		for (const e of this._edges) {
 			if (undirect && !e.direct && (e[0] === k || e[1] === k)) {
-				const t = e[0] === k ? e[1] : e[0]
-				if (cons[t]) continue
-				nodes.push(t)
-				cons[t] = true
+				nodesSet.add(e[0] === k ? e[1] : e[0])
 			} else if (direct === true && e.direct && (e[0] === k || e[1] === k)) {
-				const t = e[0] === k ? e[1] : e[0]
-				if (cons[t]) continue
-				nodes.push(t)
-				cons[t] = true
+				nodesSet.add(e[0] === k ? e[1] : e[0])
 			} else if (direct === 'in' && e.direct && e[1] === k) {
-				if (cons[e[0]]) continue
-				nodes.push(e[0])
-				cons[e[0]] = true
+				nodesSet.add(e[0])
 			} else if (direct === 'out' && e.direct && e[0] === k) {
-				if (cons[e[1]]) continue
-				nodes.push(e[1])
-				cons[e[1]] = true
+				nodesSet.add(e[1])
 			}
 		}
+		const nodes = [...nodesSet]
 		nodes.sort((a, b) => a - b)
 		return nodes
 	}
@@ -1102,15 +1102,7 @@ export default class Graph {
 	 * @returns {number[][]} Indexes of each biconnected components
 	 */
 	biconnectedComponents() {
-		const n = this._nodes.length
-		const structure = new Graph(n)
-		const conChecks = Array.from({ length: n }, () => Array(n).fill(false))
-		for (const e of this._edges) {
-			if (e[0] !== e[1] && !conChecks[e[0]][e[1]]) {
-				structure.addEdge(e[0], e[1])
-				conChecks[e[0]][e[1]] = conChecks[e[1]][e[0]] = true
-			}
-		}
+		const structure = this.toSimple().toUndirected()
 		const notcheckedComponents = structure.components()
 		const components = []
 		while (notcheckedComponents.length > 0) {
@@ -1390,23 +1382,26 @@ export default class Graph {
 	 * @returns {number} Chromatic index
 	 */
 	chromaticIndex() {
-		if (this._edges.length <= 1) {
-			return this._edges.length
-		}
-		if (this.isBipartite()) {
-			let maxd = 0
-			for (let i = 0; i < this._nodes.length; i++) {
-				maxd = Math.max(maxd, this.degree(i))
+		const components = this.components()
+		let maxci = 0
+		for (let k = 0; k < components.length; k++) {
+			const g = this.inducedSub(components[k])
+			let ci = -1
+			if (g._edges.length <= 1) {
+				ci = g._edges.length
+			} else if (g.isBipartite()) {
+				ci = 0
+				for (let i = 0; i < g._nodes.length; i++) {
+					ci = Math.max(ci, g.degree(i))
+				}
+			} else if (g.isComplete()) {
+				ci = g._nodes.length % 2 === 0 ? g._nodes.length - 1 : g._nodes.length
+			} else {
+				throw new GraphException('Not implemented')
 			}
-			return maxd
+			maxci = Math.max(maxci, ci)
 		}
-		if (this.isComplete()) {
-			if (this._nodes.length % 2 === 0) {
-				return this._nodes.length - 1
-			}
-			return this._nodes.length
-		}
-		throw new GraphException('Not implemented')
+		return maxci
 	}
 
 	/**
@@ -1608,6 +1603,14 @@ export default class Graph {
 	}
 
 	/**
+	 * Remove all nodes.
+	 */
+	clearNodes() {
+		this._nodes = []
+		this._edges = []
+	}
+
+	/**
 	 * Add the edge.
 	 *
 	 * @param {number} from Index of the starting node of the edge
@@ -1627,19 +1630,29 @@ export default class Graph {
 	 *
 	 * @param {number} from Index of the starting node of the edge
 	 * @param {number} to Index of the end node of the edge
-	 * @param {boolean | null} [direct=null] `null` to get direct and undirect edges, `true` to get only direct edges, `false` to get only undirect edges.
-	 * @returns {Edge[]} Edges between `from` to `to`
+	 * @param {boolean | 'forward' | 'backward'} [undirect=true] Get undirected edges or not. If `forward` or `backward` is specified, only direct edges are get and `direct` parameter is ignored.
+	 * @param {boolean | 'forward' | 'backward'} [direct=true] Get directed edges or not
+	 * @returns {Edge[]} Edges between `from` and `to`
 	 */
-	getEdges(from, to, direct = null) {
+	getEdges(from, to, undirect = true, direct = true) {
 		if (from < 0 || this._nodes.length <= from || to < 0 || this._nodes.length <= to) {
 			throw new GraphException('Index out of bounds.')
 		}
+		if (undirect === 'forward' || undirect === 'backward') {
+			direct = undirect
+			undirect = false
+		}
 		const edges = []
 		for (const e of this._edges) {
-			if (direct === null || !direct === !e.direct) {
-				if ((e[0] === from && e[1] === to) || (e[1] === from && e[0] === to)) {
-					edges.push(e)
-				}
+			if (
+				((undirect && !e.direct) || (direct === true && e.direct)) &&
+				((e[0] === from && e[1] === to) || (e[0] === to && e[1] === from))
+			) {
+				edges.push(e)
+			} else if (direct === 'forward' && e.direct && e[0] === from && e[1] === to) {
+				edges.push(e)
+			} else if (direct === 'backward' && e.direct && e[0] === to && e[1] === from) {
+				edges.push(e)
 			}
 		}
 		return edges
@@ -1664,6 +1677,13 @@ export default class Graph {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Remove all edges.
+	 */
+	clearEdges() {
+		this._edges = []
 	}
 
 	/**
@@ -1692,37 +1712,23 @@ export default class Graph {
 	 */
 	adjacencyList(direct = 'both') {
 		const n = this._nodes.length
-		const a = Array.from({ length: n }, () => [])
-		const conChecks = Array.from({ length: n }, () => Array(n).fill(false))
+		const a = Array.from({ length: n }, () => new Set())
 		for (const e of this._edges) {
 			if (e[0] === e[1]) {
-				if (!conChecks[e[0]][e[1]]) {
-					a[e[0]].push(e[1])
-					conChecks[e[0]][e[1]] = true
-				}
+				a[e[0]].add(e[1])
 			} else if (e.direct && direct !== 'both') {
 				if (direct === 'in') {
-					if (!conChecks[e[1]][e[0]]) {
-						a[e[1]].push(e[0])
-						conChecks[e[1]][e[0]] = true
-					}
+					a[e[1]].add(e[0])
 				} else {
-					if (!conChecks[e[0]][e[1]]) {
-						a[e[0]].push(e[1])
-						conChecks[e[0]][e[1]] = true
-					}
+					a[e[0]].add(e[1])
 				}
 			} else {
-				if (!conChecks[e[0]][e[1]]) {
-					a[e[0]].push(e[1])
-				}
-				if (!conChecks[e[1]][e[0]]) {
-					a[e[1]].push(e[0])
-				}
-				conChecks[e[0]][e[1]] = conChecks[e[1]][e[0]] = true
+				a[e[0]].add(e[1])
+				a[e[1]].add(e[0])
 			}
 		}
 		for (let i = 0; i < n; i++) {
+			a[i] = [...a[i]]
 			a[i].sort((a, b) => a - b)
 		}
 		return a
@@ -2003,15 +2009,7 @@ export default class Graph {
 	 * @returns {boolean} `true` if this is plainer graph
 	 */
 	isPlainer() {
-		const n = this._nodes.length
-		const structure = new Graph(n)
-		const conChecks = Array.from({ length: n }, () => Array(n).fill(false))
-		for (const e of this._edges) {
-			if (e[0] !== e[1] && !conChecks[e[0]][e[1]]) {
-				structure.addEdge(e[0], e[1])
-				conChecks[e[0]][e[1]] = conChecks[e[1]][e[0]] = true
-			}
-		}
+		const structure = this.toSimple().toUndirected()
 		const components = structure.components()
 		return components.every(comp => {
 			const g = structure.inducedSub(comp)
@@ -2069,6 +2067,321 @@ export default class Graph {
 	 * @returns {boolean} `true` if this is plainer graph
 	 */
 	isPlainerAddVertex() {
+		const bubble = (tree, set) => {
+			let blockCount = 0
+			let offTheTop = 0
+			const queue = []
+			const nodes = [tree]
+			while (nodes.length > 0) {
+				const node = nodes.pop()
+				if (node.children && node.children.length > 0) {
+					nodes.push(...node.children)
+				} else if (set.includes(node.value)) {
+					queue.push(node)
+				}
+			}
+			while (queue.length + blockCount + offTheTop > 1) {
+				if (queue.length === 0) {
+					return false
+				}
+				const x = queue.shift()
+				x.mark = 'blocked'
+				const xidx = x.parent?.children.indexOf(x) ?? null
+				const imsib = []
+				if (xidx !== null && x.parent.type === 'q') {
+					if (xidx > 0) {
+						imsib.push(x.parent.children[xidx - 1])
+					}
+					if (xidx < x.parent.children.length - 1) {
+						imsib.push(x.parent.children[xidx + 1])
+					}
+				}
+				const bs = imsib.filter(y => y.mark === 'blocked')
+				const us = imsib.filter(y => y.mark === 'unblocked')
+				if (us.length > 0 || imsib.length < 2) {
+					x.mark = 'unblocked'
+				}
+				if (x.mark === 'unblocked') {
+					const y = x.parent
+					if (bs.length > 0) {
+						for (let i = xidx - 1; i >= 0; i--) {
+							if (y.children[i].mark !== 'blocked') {
+								break
+							}
+							y.children[i].mark = 'unblocked'
+							y.pertinentChildCount = (y.pertinentChildCount ?? 0) + 1
+						}
+						for (let i = xidx + 1; i < y.children.length; i++) {
+							if (y.children[i].mark !== 'blocked') {
+								break
+							}
+							y.children[i].mark = 'unblocked'
+							y.pertinentChildCount = (y.pertinentChildCount ?? 0) + 1
+						}
+					}
+					if (!y) {
+						offTheTop = 1
+					} else {
+						y.pertinentChildCount = (y.pertinentChildCount ?? 0) + 1
+						if (!y.mark) {
+							y.mark = 'queued'
+							queue.push(y)
+						}
+					}
+					blockCount -= bs.length
+				} else {
+					blockCount += 1 - bs.length
+				}
+			}
+			return true
+		}
+		const reduce = (tree, set) => {
+			const queue = [tree]
+			while (true) {
+				const newQueue = []
+				let changed = false
+				for (let i = 0; i < queue.length; i++) {
+					queue[i].label = null
+					queue[i].pertinentLeafCount = 0
+					if (queue[i].children && queue[i].children.length > 0) {
+						newQueue.push(...queue[i].children)
+						changed = true
+					} else if (set.includes(queue[i].value)) {
+						queue[i].pertinentLeafCount = 1
+						newQueue.push(queue[i])
+					} else {
+						newQueue.push(queue[i])
+					}
+				}
+				queue.splice(0, queue.length, ...newQueue)
+				if (!changed) break
+			}
+			const needCount = queue.reduce((s, v) => s + (set.includes(v.value) ? 1 : 0), 0)
+			while (queue.length > 0) {
+				const x = queue.shift()
+				if (x.parent) {
+					x.parent.pertinentLeafCount += x.pertinentLeafCount
+				}
+				if (!x.children || x.children.length === 0) {
+					x.label = set.includes(x.value) ? 'full' : 'empty'
+				} else {
+					const cempty = []
+					const cfull = []
+					const cpartial = []
+					for (let i = 0; i < x.children.length; i++) {
+						if (x.children[i].label === 'empty') {
+							cempty.push(x.children[i])
+						} else if (x.children[i].label === 'full') {
+							cfull.push(x.children[i])
+						} else {
+							cpartial.push(x.children[i])
+						}
+					}
+					if (cempty.length === x.children.length) {
+						x.label = 'empty'
+					} else if (cfull.length === x.children.length) {
+						x.label = 'full'
+					} else if (x.type === 'p') {
+						if (cempty.length + cfull.length === x.children.length) {
+							if (x.pertinentLeafCount === needCount) {
+								x.children = cempty
+								const c = { type: 'p', children: cfull, label: 'full', parent: x }
+								c.children.forEach(n => (n.parent = c))
+								x.children.push(c)
+							} else {
+								x.type = 'q'
+								x.children = []
+								if (cempty.length === 1) {
+									x.children.push(cempty[0])
+								} else {
+									const c = { type: 'p', children: cempty, label: 'empty', parent: x }
+									c.children.forEach(n => (n.parent = c))
+									x.children.push(c)
+								}
+								if (cfull.length === 1) {
+									x.children.push(cfull[0])
+								} else {
+									const c = { type: 'p', children: cfull, label: 'full', parent: x }
+									c.children.forEach(n => (n.parent = c))
+									x.children.push(c)
+								}
+								x.label = 'partial'
+							}
+						} else {
+							if (x.pertinentLeafCount === needCount) {
+								x.children = cempty
+								if (cpartial.length === 1) {
+									x.children.push(cpartial[0])
+									if (cfull.length > 0) {
+										const c = { type: 'p', children: cfull, label: 'full', parent: cpartial[0] }
+										c.children.forEach(n => (n.parent = c))
+										cpartial[0].children.push(c)
+									}
+								} else if (cpartial.length === 2) {
+									const c = { type: 'q', children: [], label: 'partial' }
+									c.children.push(...cpartial[0].children)
+									c.children.push(...cfull)
+									c.children.push(...cpartial[1].children.reverse())
+									c.children.forEach(n => (n.parent = c))
+									x.children.push(c)
+									x.children.forEach(n => (n.parent = x))
+								} else {
+									return false
+								}
+							} else if (cpartial.length === 1) {
+								x.type = 'q'
+								x.children = []
+								if (cempty.length > 0) {
+									const c = { type: 'p', children: cempty, label: 'empty' }
+									c.children.forEach(n => (n.parent = c))
+									x.children.push(c)
+								}
+								x.children.push(...cpartial[0].children)
+								if (cfull.length > 0) {
+									const c = { type: 'p', children: cfull, label: 'full' }
+									c.children.forEach(n => (n.parent = c))
+									x.children.push(c)
+								}
+								x.label = 'partial'
+								x.children.forEach(n => (n.parent = x))
+							} else {
+								return false
+							}
+						}
+					} else if (x.type === 'q') {
+						if (x.children.at(-1).label === 'empty') {
+							x.children.reverse()
+						}
+						if (x.pertinentLeafCount === needCount) {
+							if (cpartial.length === 0) {
+								let reqState = 'empty'
+								let flipCount = 0
+								for (let i = 0; i < x.children.length; i++) {
+									if (x.children[i].label !== reqState && flipCount < 2) {
+										reqState = reqState === 'empty' ? 'full' : 'empty'
+										flipCount++
+									} else if (x.children[i].label !== reqState) {
+										return false
+									}
+								}
+							} else if (cpartial.length === 1) {
+								let reqState = 'empty'
+								let flipCount = 0
+								const cn = []
+								for (let i = 0; i < x.children.length; i++) {
+									if (x.children[i].label === 'partial') {
+										if (reqState === 'empty') {
+											cn.push(...x.children[i].children)
+											reqState = 'full'
+										} else {
+											cn.push(...x.children[i].children.reverse())
+											reqState = 'empty'
+										}
+									} else if (x.children[i].label !== reqState && flipCount < 1) {
+										reqState = reqState === 'empty' ? 'full' : 'empty'
+										flipCount++
+										cn.push(x.children[i])
+									} else if (x.children[i].label === reqState) {
+										cn.push(x.children[i])
+									} else {
+										return false
+									}
+								}
+								x.children = cn
+								x.children.forEach(n => (n.parent = x))
+							} else if (cpartial.length === 2) {
+								let reqState = 'empty'
+								const cn = []
+								for (let i = 0; i < x.children.length; i++) {
+									if (x.children[i].label === 'partial') {
+										if (reqState === 'empty') {
+											cn.push(...x.children[i].children)
+											reqState = 'full'
+										} else {
+											cn.push(...x.children[i].children.reverse())
+											reqState = 'empty'
+										}
+									} else if (x.children[i].label === reqState) {
+										cn.push(x.children[i])
+									} else {
+										return false
+									}
+								}
+								x.children = cn
+								x.children.forEach(n => (n.parent = x))
+							} else {
+								return false
+							}
+						} else {
+							if (cpartial.length === 0) {
+								let reqState = 'empty'
+								for (let i = 0; i < x.children.length; i++) {
+									if (x.children[i].label === 'full') {
+										reqState = 'full'
+									} else if (x.children[i].label !== reqState) {
+										return false
+									}
+								}
+							} else if (cpartial.length === 1) {
+								let reqState = 'empty'
+								const cn = []
+								for (let i = 0; i < x.children.length; i++) {
+									if (x.children[i].label === 'partial') {
+										cn.push(...x.children[i].children)
+										reqState = 'full'
+									} else if (x.children[i].label === reqState) {
+										cn.push(x.children[i])
+									} else {
+										return false
+									}
+								}
+								x.children = cn
+								x.children.forEach(n => (n.parent = x))
+							} else {
+								return false
+							}
+						}
+						x.label = 'partial'
+					}
+				}
+				if (x.pertinentLeafCount === needCount) {
+					break
+				} else if (x.parent) {
+					if (x.parent.children.every(y => y.label)) {
+						queue.push(x.parent)
+					}
+				}
+			}
+			return true
+		}
+		const getRoot = (tree, set) => {
+			const stack = []
+			const nodes = [tree]
+			while (nodes.length > 0) {
+				const node = nodes.pop()
+				if (node.children && node.children.length > 0) {
+					node.pertinentLeafCount = 0
+					nodes.push(...node.children)
+				} else if (set.includes(node.value)) {
+					node.pertinentLeafCount = 1
+					stack.push(node)
+				}
+			}
+			const needCount = stack.length
+			while (stack.length > 0) {
+				const node = stack.pop()
+				if (node.pertinentLeafCount === needCount) {
+					return node
+				}
+				const parent = node.parent
+				if (parent) {
+					parent.pertinentLeafCount++
+					stack.push(parent)
+				}
+			}
+			return tree
+		}
+
 		const components = this.biconnectedComponents()
 		return components.every(comp => {
 			const sg = this.inducedSub(comp)
@@ -2087,321 +2400,6 @@ export default class Graph {
 
 			const root = { type: 'p', children: alist[order[0]].map(v => ({ value: v })) }
 			root.children.forEach(n => (n.parent = root))
-			const bubble = (tree, set) => {
-				let blockCount = 0
-				let offTheTop = 0
-				const queue = []
-				const nodes = [tree]
-				while (nodes.length > 0) {
-					const node = nodes.pop()
-					if (node.children && node.children.length > 0) {
-						nodes.push(...node.children)
-					} else if (set.includes(node.value)) {
-						queue.push(node)
-					}
-				}
-				while (queue.length + blockCount + offTheTop > 1) {
-					if (queue.length === 0) {
-						return false
-					}
-					const x = queue.shift()
-					x.mark = 'blocked'
-					const xidx = x.parent?.children.indexOf(x) ?? null
-					const imsib = []
-					if (xidx !== null && x.parent.type === 'q') {
-						if (xidx > 0) {
-							imsib.push(x.parent.children[xidx - 1])
-						}
-						if (xidx < x.parent.children.length - 1) {
-							imsib.push(x.parent.children[xidx + 1])
-						}
-					}
-					const bs = imsib.filter(y => y.mark === 'blocked')
-					const us = imsib.filter(y => y.mark === 'unblocked')
-					if (us.length > 0 || imsib.length < 2) {
-						x.mark = 'unblocked'
-					}
-					if (x.mark === 'unblocked') {
-						const y = x.parent
-						if (bs.length > 0) {
-							for (let i = xidx - 1; i >= 0; i--) {
-								if (y.children[i].mark !== 'blocked') {
-									break
-								}
-								y.children[i].mark = 'unblocked'
-								y.pertinentChildCount = (y.pertinentChildCount ?? 0) + 1
-							}
-							for (let i = xidx + 1; i < y.children.length; i++) {
-								if (y.children[i].mark !== 'blocked') {
-									break
-								}
-								y.children[i].mark = 'unblocked'
-								y.pertinentChildCount = (y.pertinentChildCount ?? 0) + 1
-							}
-						}
-						if (!y) {
-							offTheTop = 1
-						} else {
-							y.pertinentChildCount = (y.pertinentChildCount ?? 0) + 1
-							if (!y.mark) {
-								y.mark = 'queued'
-								queue.push(y)
-							}
-						}
-						blockCount -= bs.length
-					} else {
-						blockCount += 1 - bs.length
-					}
-				}
-				return true
-			}
-			const reduce = (tree, set) => {
-				const queue = [tree]
-				while (true) {
-					const newQueue = []
-					let changed = false
-					for (let i = 0; i < queue.length; i++) {
-						queue[i].label = null
-						queue[i].pertinentLeafCount = 0
-						if (queue[i].children && queue[i].children.length > 0) {
-							newQueue.push(...queue[i].children)
-							changed = true
-						} else if (set.includes(queue[i].value)) {
-							queue[i].pertinentLeafCount = 1
-							newQueue.push(queue[i])
-						} else {
-							newQueue.push(queue[i])
-						}
-					}
-					queue.splice(0, queue.length, ...newQueue)
-					if (!changed) break
-				}
-				const needCount = queue.reduce((s, v) => s + (set.includes(v.value) ? 1 : 0), 0)
-				while (queue.length > 0) {
-					const x = queue.shift()
-					if (x.parent) {
-						x.parent.pertinentLeafCount += x.pertinentLeafCount
-					}
-					if (!x.children || x.children.length === 0) {
-						x.label = set.includes(x.value) ? 'full' : 'empty'
-					} else {
-						const cempty = []
-						const cfull = []
-						const cpartial = []
-						for (let i = 0; i < x.children.length; i++) {
-							if (x.children[i].label === 'empty') {
-								cempty.push(x.children[i])
-							} else if (x.children[i].label === 'full') {
-								cfull.push(x.children[i])
-							} else {
-								cpartial.push(x.children[i])
-							}
-						}
-						if (cempty.length === x.children.length) {
-							x.label = 'empty'
-						} else if (cfull.length === x.children.length) {
-							x.label = 'full'
-						} else if (x.type === 'p') {
-							if (cempty.length + cfull.length === x.children.length) {
-								if (x.pertinentLeafCount === needCount) {
-									x.children = cempty
-									const c = { type: 'p', children: cfull, label: 'full', parent: x }
-									c.children.forEach(n => (n.parent = c))
-									x.children.push(c)
-								} else {
-									x.type = 'q'
-									x.children = []
-									if (cempty.length === 1) {
-										x.children.push(cempty[0])
-									} else {
-										const c = { type: 'p', children: cempty, label: 'empty', parent: x }
-										c.children.forEach(n => (n.parent = c))
-										x.children.push(c)
-									}
-									if (cfull.length === 1) {
-										x.children.push(cfull[0])
-									} else {
-										const c = { type: 'p', children: cfull, label: 'full', parent: x }
-										c.children.forEach(n => (n.parent = c))
-										x.children.push(c)
-									}
-									x.label = 'partial'
-								}
-							} else {
-								if (x.pertinentLeafCount === needCount) {
-									x.children = cempty
-									if (cpartial.length === 1) {
-										x.children.push(cpartial[0])
-										if (cfull.length > 0) {
-											const c = { type: 'p', children: cfull, label: 'full', parent: cpartial[0] }
-											c.children.forEach(n => (n.parent = c))
-											cpartial[0].children.push(c)
-										}
-									} else if (cpartial.length === 2) {
-										const c = { type: 'q', children: [], label: 'partial' }
-										c.children.push(...cpartial[0].children)
-										c.children.push(...cfull)
-										c.children.push(...cpartial[1].children.reverse())
-										c.children.forEach(n => (n.parent = c))
-										x.children.push(c)
-										x.children.forEach(n => (n.parent = x))
-									} else {
-										return false
-									}
-								} else if (cpartial.length === 1) {
-									x.type = 'q'
-									x.children = []
-									if (cempty.length > 0) {
-										const c = { type: 'p', children: cempty, label: 'empty' }
-										c.children.forEach(n => (n.parent = c))
-										x.children.push(c)
-									}
-									x.children.push(...cpartial[0].children)
-									if (cfull.length > 0) {
-										const c = { type: 'p', children: cfull, label: 'full' }
-										c.children.forEach(n => (n.parent = c))
-										x.children.push(c)
-									}
-									x.label = 'partial'
-									x.children.forEach(n => (n.parent = x))
-								} else {
-									return false
-								}
-							}
-						} else if (x.type === 'q') {
-							if (x.children.at(-1).label === 'empty') {
-								x.children.reverse()
-							}
-							if (x.pertinentLeafCount === needCount) {
-								if (cpartial.length === 0) {
-									let reqState = 'empty'
-									let flipCount = 0
-									for (let i = 0; i < x.children.length; i++) {
-										if (x.children[i].label !== reqState && flipCount < 2) {
-											reqState = reqState === 'empty' ? 'full' : 'empty'
-											flipCount++
-										} else if (x.children[i].label !== reqState) {
-											return false
-										}
-									}
-								} else if (cpartial.length === 1) {
-									let reqState = 'empty'
-									let flipCount = 0
-									const cn = []
-									for (let i = 0; i < x.children.length; i++) {
-										if (x.children[i].label === 'partial') {
-											if (reqState === 'empty') {
-												cn.push(...x.children[i].children)
-												reqState = 'full'
-											} else {
-												cn.push(...x.children[i].children.reverse())
-												reqState = 'empty'
-											}
-										} else if (x.children[i].label !== reqState && flipCount < 1) {
-											reqState = reqState === 'empty' ? 'full' : 'empty'
-											flipCount++
-											cn.push(x.children[i])
-										} else if (x.children[i].label === reqState) {
-											cn.push(x.children[i])
-										} else {
-											return false
-										}
-									}
-									x.children = cn
-									x.children.forEach(n => (n.parent = x))
-								} else if (cpartial.length === 2) {
-									let reqState = 'empty'
-									const cn = []
-									for (let i = 0; i < x.children.length; i++) {
-										if (x.children[i].label === 'partial') {
-											if (reqState === 'empty') {
-												cn.push(...x.children[i].children)
-												reqState = 'full'
-											} else {
-												cn.push(...x.children[i].children.reverse())
-												reqState = 'empty'
-											}
-										} else if (x.children[i].label === reqState) {
-											cn.push(x.children[i])
-										} else {
-											return false
-										}
-									}
-									x.children = cn
-									x.children.forEach(n => (n.parent = x))
-								} else {
-									return false
-								}
-							} else {
-								if (cpartial.length === 0) {
-									let reqState = 'empty'
-									for (let i = 0; i < x.children.length; i++) {
-										if (x.children[i].label === 'full') {
-											reqState = 'full'
-										} else if (x.children[i].label !== reqState) {
-											return false
-										}
-									}
-								} else if (cpartial.length === 1) {
-									let reqState = 'empty'
-									const cn = []
-									for (let i = 0; i < x.children.length; i++) {
-										if (x.children[i].label === 'partial') {
-											cn.push(...x.children[i].children)
-											reqState = 'full'
-										} else if (x.children[i].label === reqState) {
-											cn.push(x.children[i])
-										} else {
-											return false
-										}
-									}
-									x.children = cn
-									x.children.forEach(n => (n.parent = x))
-								} else {
-									return false
-								}
-							}
-							x.label = 'partial'
-						}
-					}
-					if (x.pertinentLeafCount === needCount) {
-						break
-					} else if (x.parent) {
-						if (x.parent.children.every(y => y.label)) {
-							queue.push(x.parent)
-						}
-					}
-				}
-				return true
-			}
-			const getRoot = (tree, set) => {
-				const stack = []
-				const nodes = [tree]
-				while (nodes.length > 0) {
-					const node = nodes.pop()
-					if (node.children && node.children.length > 0) {
-						node.pertinentLeafCount = 0
-						nodes.push(...node.children)
-					} else if (set.includes(node.value)) {
-						node.pertinentLeafCount = 1
-						stack.push(node)
-					}
-				}
-				const needCount = stack.length
-				while (stack.length > 0) {
-					const node = stack.pop()
-					if (node.pertinentLeafCount === needCount) {
-						return node
-					}
-					const parent = node.parent
-					if (parent) {
-						parent.pertinentLeafCount++
-						stack.push(parent)
-					}
-				}
-				return tree
-			}
-
 			for (let k = 1; k < n; k++) {
 				const f1 = bubble(root, [order[k]])
 				const f2 = reduce(root, [order[k]])
@@ -2565,6 +2563,9 @@ export default class Graph {
 		if (this._nodes.length <= 1) {
 			return true
 		}
+		if (this._edges.length <= 1) {
+			return true
+		}
 		throw new GraphException('Not implemented')
 	}
 
@@ -2584,6 +2585,129 @@ export default class Graph {
 	 */
 	isSeparable() {
 		return !this.isBiconnected()
+	}
+
+	/**
+	 * Returns if this is Eulerian graph or not.
+	 *
+	 * @returns {boolean} `true` if this is Eulerian graph
+	 */
+	isEulerian() {
+		if (!this.isConnected()) {
+			return false
+		}
+		const deg = Array.from(this._nodes, () => ({ und: 0, dir: 0 }))
+		for (const edge of this._edges) {
+			if (!edge.direct) {
+				deg[edge[0]].und++
+				deg[edge[1]].und++
+			} else {
+				deg[edge[0]].dir--
+				deg[edge[1]].dir++
+			}
+		}
+		for (let i = 0; i < deg.length; i++) {
+			if (Math.abs(deg[i].dir) > deg[i].und) {
+				return false
+			} else if ((deg[i].und - Math.abs(deg[i].dir)) % 2 === 1) {
+				return false
+			}
+		}
+		return true
+	}
+
+	/**
+	 * Returns if this is semi-Eulerian graph or not.
+	 *
+	 * @returns {boolean} `true` if this is semi-Eulerian graph
+	 */
+	isSemiEulerian() {
+		if (!this.isConnected()) {
+			return false
+		}
+		const deg = Array.from(this._nodes, () => ({ und: 0, dir: 0 }))
+		for (const edge of this._edges) {
+			if (!edge.direct) {
+				deg[edge[0]].und++
+				deg[edge[1]].und++
+			} else {
+				deg[edge[0]].dir--
+				deg[edge[1]].dir++
+			}
+		}
+		let undOdd = 0
+		let dirIn = 0
+		let dirOut = 0
+		for (let i = 0; i < deg.length; i++) {
+			if (Math.abs(deg[i].dir) <= deg[i].und) {
+				if ((deg[i].und - Math.abs(deg[i].dir)) % 2 === 1) {
+					undOdd++
+				}
+			} else if (Math.abs(deg[i].dir) >= 2) {
+				return false
+			} else if (deg[i].dir > 0) {
+				dirIn++
+			} else {
+				dirOut++
+			}
+			if (undOdd + dirIn + dirOut > 2 || dirIn >= 2 || dirOut >= 2) {
+				return false
+			}
+		}
+		if (undOdd === 0 && dirIn === 0 && dirOut === 0) {
+			return false
+		}
+		return true
+	}
+
+	/**
+	 * Returns if this is Hamiltonian graph or not.
+	 *
+	 * @returns {boolean} `true` if this is Hamiltonian graph
+	 */
+	isHamiltonian() {
+		if (this._nodes.length >= 3 && this.isSimple()) {
+			let mindeg = Infinity
+			for (let i = 0; i < this._nodes.length; i++) {
+				mindeg = Math.min(mindeg, this.degree(i))
+			}
+			if (mindeg >= this._nodes.length / 2) {
+				return true
+			}
+		}
+		if (!this.isConnected()) {
+			return false
+		}
+		const hamiltonian = this.hamiltonianCycle()
+		return hamiltonian.length > 0
+	}
+
+	/**
+	 * Returns if this is semi-Hamiltonian graph or not.
+	 *
+	 * @returns {boolean} `true` if this is semi-Hamiltonian graph
+	 */
+	isSemiHamiltonian() {
+		if (this._nodes.length >= 3 && this.isSimple()) {
+			let mindeg = Infinity
+			for (let i = 0; i < this._nodes.length; i++) {
+				mindeg = Math.min(mindeg, this.degree(i))
+			}
+			if (mindeg >= this._nodes.length / 2) {
+				return false
+			}
+		}
+		if (!this.isConnected()) {
+			return false
+		}
+		const hamiltonianPath = this.hamiltonianPath()
+		if (hamiltonianPath.length === 0) {
+			return false
+		}
+		if (this._nodes.length <= 2) {
+			return this.hamiltonianCycle().length === 0
+		}
+		return hamiltonianPath.every(p => this.getEdges(p.at(-1), p[0], true, 'forward').length === 0)
 	}
 
 	/**
@@ -2669,7 +2793,7 @@ export default class Graph {
 					if (!e.direct && e[1] === i) {
 						if (e[0] === s) {
 							return true
-						} else if (path.includes(e[1])) {
+						} else if (path.includes(e[0])) {
 							continue
 						}
 						const u = used.concat()
@@ -2680,6 +2804,37 @@ export default class Graph {
 			}
 		}
 		return false
+	}
+
+	/**
+	 * Returns graph of directed edges converted to undirected.
+	 *
+	 * @returns {Graph} Undirected graph
+	 */
+	toUndirected() {
+		const graph = this.copy()
+		for (const edge of graph._edges) {
+			edge.direct = false
+		}
+		return graph
+	}
+
+	/**
+	 * Returns a graph with multiple edges and loops removed.
+	 *
+	 * @returns {Graph} Simple graph
+	 */
+	toSimple() {
+		const n = this._nodes.length
+		const graph = new Graph(this._nodes.concat())
+		const conChecks = Array.from({ length: n }, () => Array(n).fill(false))
+		for (const e of this._edges) {
+			if (e[0] !== e[1] && !conChecks[e[0]][e[1]]) {
+				graph.addEdge(e[0], e[1], e.value0, e.direct)
+				conChecks[e[0]][e[1]] = conChecks[e[1]][e[0]] = true
+			}
+		}
+		return graph
 	}
 
 	/**
@@ -2836,6 +2991,26 @@ export default class Graph {
 	}
 
 	/**
+	 * Returns line graph.
+	 *
+	 * @returns {Graph} Line graph
+	 */
+	line() {
+		const g = new Graph(this._edges.concat())
+		const n = g._nodes.length
+		for (let i = 0; i < n; i++) {
+			for (let j = 0; j < i; j++) {
+				if (g._nodes[i][0] === g._nodes[j][0] || g._nodes[i][0] === g._nodes[j][1]) {
+					g.addEdge(i, j, this._nodes[g._nodes[i][0]])
+				} else if (g._nodes[i][1] === g._nodes[j][0] || g._nodes[i][1] === g._nodes[j][1]) {
+					g.addEdge(i, j, this._nodes[g._nodes[i][1]])
+				}
+			}
+		}
+		return g
+	}
+
+	/**
 	 * Contract this graph.
 	 *
 	 * @param {number} a Index of node
@@ -2881,7 +3056,27 @@ export default class Graph {
 			if ((e[0] === a && e[1] === b) || (e[1] === a && e[0] === b)) {
 				this._edges.splice(i, 1)
 				this._edges.push(new Edge(e[0], k, e.value0, e.direct))
-				this._edges.push(new Edge(k, e[0], e.value0, e.direct))
+				this._edges.push(new Edge(k, e[1], e.value0, e.direct))
+			}
+		}
+	}
+
+	/**
+	 * Cleave the node.
+	 *
+	 * @param {number} a Index of node
+	 */
+	cleaving(a) {
+		this._nodes.push(null)
+		const k = this._nodes.length - 1
+		for (let i = this._edges.length - 1; i >= 0; i--) {
+			const e = this._edges[i]
+			if (e[0] === a && e[1] === a) {
+				this._edges.push(new Edge(k, k, e.value0, e.direct))
+			} else if (e[0] === a) {
+				this._edges.push(new Edge(k, e[1], e.value0, e.direct))
+			} else if (e[1] === a) {
+				this._edges.push(new Edge(e[0], k, e.value0, e.direct))
 			}
 		}
 	}
@@ -2946,7 +3141,7 @@ export default class Graph {
 		for (let i = 0; i < n1; i++) {
 			for (let j = 0; j < n2; j++) {
 				if (this._nodes[i] != null || g._nodes[j] != null) {
-					nodes.push([this._nodes[i], this._nodes[j]])
+					nodes.push([this._nodes[i], g._nodes[j]])
 				} else {
 					nodes.push(null)
 				}
@@ -2979,7 +3174,7 @@ export default class Graph {
 		for (let i = 0; i < n1; i++) {
 			for (let j = 0; j < n2; j++) {
 				if (this._nodes[i] != null || g._nodes[j] != null) {
-					nodes.push([this._nodes[i], this._nodes[j]])
+					nodes.push([this._nodes[i], g._nodes[j]])
 				} else {
 					nodes.push(null)
 				}
@@ -3026,7 +3221,7 @@ export default class Graph {
 		for (let i = 0; i < n1; i++) {
 			for (let j = 0; j < n2; j++) {
 				if (this._nodes[i] != null || g._nodes[j] != null) {
-					nodes.push([this._nodes[i], this._nodes[j]])
+					nodes.push([this._nodes[i], g._nodes[j]])
 				} else {
 					nodes.push(null)
 				}
@@ -3083,7 +3278,7 @@ export default class Graph {
 		for (let i = 0; i < n1; i++) {
 			for (let j = 0; j < n2; j++) {
 				if (this._nodes[i] != null || g._nodes[j] != null) {
-					nodes.push([this._nodes[i], this._nodes[j]])
+					nodes.push([this._nodes[i], g._nodes[j]])
 				} else {
 					nodes.push(null)
 				}
@@ -3351,6 +3546,85 @@ export default class Graph {
 			}
 		}
 		return new Graph(this._nodes.length, [...edges])
+	}
+
+	/**
+	 * Returns Hamiltonian path
+	 *
+	 * @param {number} [from] Index of start node
+	 * @returns {number[][]} Hamiltonian path
+	 */
+	hamiltonianPath(from) {
+		if (!this.isConnected()) {
+			return []
+		}
+		return this.hamiltonianPathDynamicProgramming(from)
+	}
+
+	/**
+	 * Returns Hamiltonian path with dynamic programming
+	 *
+	 * @param {number} [from] Index of start node
+	 * @returns {number[][]} Hamiltonian path
+	 */
+	hamiltonianPathDynamicProgramming(from) {
+		const n = this._nodes.length
+		let /** @type {{s: Set<number>, v: Map<number, number[][]>}[]} */ lastPath = []
+		if (typeof from === 'number') {
+			lastPath.push({ s: new Set([from]), v: new Map([[from, [[from]]]]) })
+		} else {
+			for (let i = 0; i < n; i++) {
+				lastPath.push({ s: new Set([i]), v: new Map([[i, [[i]]]]) })
+			}
+		}
+		const adjList = this.adjacencyList('in')
+		for (let k = 1; k < n; k++) {
+			const nextPath = []
+			for (let i = 0; i < n; i++) {
+				for (let c = 0; c < lastPath.length; c++) {
+					const p = lastPath[c]
+					if (p.s.has(i)) continue
+					const path = []
+					for (const v of p.v.keys()) {
+						if (adjList[i].indexOf(v) < 0) continue
+						path.push(...p.v.get(v).map(c => [...c, i]))
+					}
+					if (path.length === 0) continue
+					const ep = nextPath.find(np => [...p.s, i].every(j => np.s.has(j)))
+					if (ep) {
+						ep.v.set(i, path)
+					} else {
+						nextPath.push({ s: new Set([...p.s, i]), v: new Map([[i, path]]) })
+					}
+				}
+			}
+			lastPath = nextPath
+		}
+		return lastPath.flatMap(p => [...p.v.values()].flat())
+	}
+
+	/**
+	 * Returns Hamiltonian cycle
+	 *
+	 * @returns {number[][]} Hamiltonian cycle
+	 */
+	hamiltonianCycle() {
+		if (!this.isConnected()) {
+			return []
+		}
+		const path = this.hamiltonianPath()
+		if (this.order <= 1) {
+			return path
+		} else if (this.order === 2) {
+			if (path.length <= 1 || this.getEdges(0, 1).length <= 1) {
+				return []
+			}
+			return [
+				[0, 1, 0],
+				[1, 0, 1],
+			]
+		}
+		return path.filter(p => this.getEdges(p.at(-1), p[0], true, 'forward').length > 0)
 	}
 
 	/**

--- a/tests/lib/util/graph.test.js
+++ b/tests/lib/util/graph.test.js
@@ -34,9 +34,39 @@ describe('graph', () => {
 			expect(graph.size).toBe(1)
 			expect(graph.edges[0]).toBeInstanceOf(Edge)
 			expect(graph.edges[0][0]).toBe(0)
+			expect(graph.edges[0].from).toBe(0)
 			expect(graph.edges[0][1]).toBe(1)
+			expect(graph.edges[0].to).toBe(1)
 			expect(graph.edges[0].value).toBe(1)
 			expect(graph.edges[0].direct).toBeFalsy()
+		})
+
+		test('edge objects', () => {
+			const graph = new Graph(2, [{ from: 0, to: 1, value: 2, direct: true }])
+
+			expect(graph.order).toBe(2)
+			expect(graph.size).toBe(1)
+			expect(graph.edges[0]).toBeInstanceOf(Edge)
+			expect(graph.edges[0][0]).toBe(0)
+			expect(graph.edges[0].from).toBe(0)
+			expect(graph.edges[0][1]).toBe(1)
+			expect(graph.edges[0].to).toBe(1)
+			expect(graph.edges[0].value).toBe(2)
+			expect(graph.edges[0].direct).toBeTruthy()
+		})
+
+		test('edge instance', () => {
+			const graph = new Graph(2, [new Edge(0, 1, 3, true)])
+
+			expect(graph.order).toBe(2)
+			expect(graph.size).toBe(1)
+			expect(graph.edges[0]).toBeInstanceOf(Edge)
+			expect(graph.edges[0][0]).toBe(0)
+			expect(graph.edges[0].from).toBe(0)
+			expect(graph.edges[0][1]).toBe(1)
+			expect(graph.edges[0].to).toBe(1)
+			expect(graph.edges[0].value).toBe(3)
+			expect(graph.edges[0].direct).toBeTruthy()
 		})
 	})
 
@@ -1187,6 +1217,17 @@ describe('graph', () => {
 		})
 	})
 
+	describe('clearNodes', () => {
+		test('default', () => {
+			const graph = Graph.complete(5)
+			graph.clearNodes()
+			expect(graph.order).toBe(0)
+			expect(graph.size).toBe(0)
+			expect(graph.isNull()).toBeTruthy()
+			expect(graph.isEdgeless()).toBeTruthy()
+		})
+	})
+
 	describe('addEdge', () => {
 		test('default', () => {
 			const graph = new Graph(3)
@@ -1270,7 +1311,7 @@ describe('graph', () => {
 
 		test('undirect', () => {
 			const graph = new Graph(3, [{ 0: 0, 1: 1, direct: true }, { 0: 0, 1: 1, direct: false }, [1, 2]])
-			const edges = graph.getEdges(0, 1, false)
+			const edges = graph.getEdges(0, 1, true, false)
 			expect(edges).toHaveLength(1)
 			expect(edges[0]).toBeInstanceOf(Edge)
 			expect(edges[0][0]).toBe(0)
@@ -1281,7 +1322,7 @@ describe('graph', () => {
 
 		test('direct', () => {
 			const graph = new Graph(3, [{ 0: 0, 1: 1, direct: true }, { 0: 0, 1: 1, direct: false }, [1, 2]])
-			const edges = graph.getEdges(0, 1, true)
+			const edges = graph.getEdges(0, 1, false, true)
 			expect(edges).toHaveLength(1)
 			expect(edges[0]).toBeInstanceOf(Edge)
 			expect(edges[0][0]).toBe(0)
@@ -1292,7 +1333,7 @@ describe('graph', () => {
 
 		test('direct both direction', () => {
 			const graph = new Graph(3, [{ 0: 0, 1: 1, direct: true }, { 0: 1, 1: 0, direct: true }, [1, 2]])
-			const edges = graph.getEdges(0, 1, true)
+			const edges = graph.getEdges(0, 1, false, true)
 			expect(edges).toHaveLength(2)
 			expect(edges[0]).toBeInstanceOf(Edge)
 			expect(edges[0][0]).toBe(0)
@@ -1304,6 +1345,37 @@ describe('graph', () => {
 			expect(edges[1][1]).toBe(0)
 			expect(edges[1].value).toBe(1)
 			expect(edges[1].direct).toBeTruthy()
+		})
+
+		test('direct forward direction', () => {
+			const graph = new Graph(3, [{ 0: 0, 1: 1, direct: true }, { 0: 1, 1: 0, direct: true }, [1, 2]])
+			const edges = graph.getEdges(0, 1, 'forward')
+			expect(edges).toHaveLength(1)
+			expect(edges[0]).toBeInstanceOf(Edge)
+			expect(edges[0][0]).toBe(0)
+			expect(edges[0][1]).toBe(1)
+			expect(edges[0].value).toBe(1)
+			expect(edges[0].direct).toBeTruthy()
+		})
+
+		test('direct backward direction', () => {
+			const graph = new Graph(3, [{ 0: 0, 1: 1, direct: true }, { 0: 1, 1: 0, direct: true }, [1, 2]])
+			const edges = graph.getEdges(0, 1, 'backward')
+			expect(edges).toHaveLength(1)
+			expect(edges[0]).toBeInstanceOf(Edge)
+			expect(edges[0][0]).toBe(1)
+			expect(edges[0][1]).toBe(0)
+			expect(edges[0].value).toBe(1)
+			expect(edges[0].direct).toBeTruthy()
+		})
+
+		test('not connect', () => {
+			const graph = new Graph(3, [
+				[0, 1],
+				[1, 2],
+			])
+			const edges = graph.getEdges(0, 2)
+			expect(edges).toHaveLength(0)
 		})
 
 		test.each([
@@ -1356,6 +1428,17 @@ describe('graph', () => {
 		])('fail %i, %i', (f, t) => {
 			const graph = new Graph(4)
 			expect(() => graph.removeEdges(f, t)).toThrow('Index out of bounds.')
+		})
+	})
+
+	describe('clearEdges', () => {
+		test('default', () => {
+			const graph = Graph.complete(5)
+			graph.clearEdges()
+			expect(graph.order).toBe(5)
+			expect(graph.size).toBe(0)
+			expect(graph.isNull()).toBeFalsy()
+			expect(graph.isEdgeless()).toBeTruthy()
 		})
 	})
 
@@ -2142,6 +2225,11 @@ describe('graph', () => {
 			const graph = new Graph(1)
 			expect(graph.isSymmetric()).toBeTruthy()
 		})
+
+		test('edgeless', () => {
+			const graph = new Graph(5)
+			expect(graph.isSymmetric()).toBeTruthy()
+		})
 	})
 
 	describe('isDAG', () => {
@@ -2175,6 +2263,167 @@ describe('graph', () => {
 				[1, 3],
 			])
 			expect(graph.isSeparable()).toBeTruthy()
+		})
+	})
+
+	describe('isEulerian', () => {
+		test.each([1, 3, 5])('complete %d', n => {
+			const graph = Graph.complete(n)
+			expect(graph.isEulerian()).toBeTruthy()
+		})
+
+		test.each([2, 4, 6])('complete %d', n => {
+			const graph = Graph.complete(n)
+			expect(graph.isEulerian()).toBeFalsy()
+		})
+
+		test('direct cycle', () => {
+			const graph = new Graph(3, [
+				{ 0: 0, 1: 1, direct: true },
+				{ 0: 1, 1: 2, direct: true },
+				{ 0: 2, 1: 0, direct: true },
+			])
+			expect(graph.isEulerian()).toBeTruthy()
+		})
+
+		test('mix cycle', () => {
+			const graph = new Graph(3, [
+				{ 0: 0, 1: 1, direct: true },
+				{ 0: 1, 1: 2, direct: false },
+				{ 0: 2, 1: 0, direct: true },
+			])
+			expect(graph.isEulerian()).toBeTruthy()
+		})
+
+		test('direct not cycle', () => {
+			const graph = new Graph(4, [
+				{ 0: 0, 1: 1, direct: true },
+				{ 0: 1, 1: 2, direct: true },
+				{ 0: 2, 1: 3, direct: true },
+				{ 0: 3, 1: 1, direct: true },
+			])
+			expect(graph.isEulerian()).toBeFalsy()
+		})
+
+		test('not connected', () => {
+			const graph = new Graph(2)
+			expect(graph.isEulerian()).toBeFalsy()
+		})
+	})
+
+	describe('isSemiEulerian', () => {
+		test('complete 2', () => {
+			const graph = Graph.complete(2)
+			expect(graph.isSemiEulerian()).toBeTruthy()
+		})
+
+		test.each([1, 3, 4, 5])('complete %d', n => {
+			const graph = Graph.complete(n)
+			expect(graph.isSemiEulerian()).toBeFalsy()
+		})
+
+		test('direct cycle', () => {
+			const graph = new Graph(3, [
+				{ 0: 0, 1: 1, direct: true },
+				{ 0: 1, 1: 2, direct: true },
+				{ 0: 2, 1: 0, direct: true },
+			])
+			expect(graph.isSemiEulerian()).toBeFalsy()
+		})
+
+		test('mix cycle', () => {
+			const graph = new Graph(3, [
+				{ 0: 0, 1: 1, direct: true },
+				{ 0: 1, 1: 2, direct: false },
+				{ 0: 2, 1: 0, direct: true },
+			])
+			expect(graph.isSemiEulerian()).toBeFalsy()
+		})
+
+		test('direct not cycle', () => {
+			const graph = new Graph(4, [
+				{ 0: 0, 1: 1, direct: true },
+				{ 0: 1, 1: 2, direct: true },
+				{ 0: 2, 1: 3, direct: true },
+				{ 0: 3, 1: 1, direct: true },
+			])
+			expect(graph.isSemiEulerian()).toBeTruthy()
+		})
+
+		test('direct multi in edge', () => {
+			const graph = new Graph(4, [
+				{ 0: 1, 1: 0, direct: true },
+				{ 0: 2, 1: 0, direct: true },
+				{ 0: 3, 1: 0, direct: true },
+				{ 0: 0, 1: 3, direct: true },
+				[1, 2],
+				[2, 3],
+			])
+			expect(graph.isSemiEulerian()).toBeFalsy()
+		})
+
+		test('not connected', () => {
+			const graph = new Graph(2)
+			expect(graph.isSemiEulerian()).toBeFalsy()
+		})
+	})
+
+	describe('isHamiltonian', () => {
+		test.each([1, 3, 4, 5, 6, 7])('complete %d', n => {
+			const graph = Graph.complete(n)
+			expect(graph.isHamiltonian()).toBeTruthy()
+		})
+
+		test('complete 2', () => {
+			const graph = Graph.complete(2)
+			expect(graph.isHamiltonian()).toBeFalsy()
+		})
+
+		test('path graph', () => {
+			const graph = new Graph(3, [
+				[0, 1],
+				[1, 2],
+			])
+			expect(graph.isHamiltonian()).toBeFalsy()
+		})
+
+		test('not connected', () => {
+			const graph = new Graph(2)
+			expect(graph.isHamiltonian()).toBeFalsy()
+		})
+	})
+
+	describe('isSemiHamiltonian', () => {
+		test.each([1, 3, 4, 5, 6, 7])('complete %d', n => {
+			const graph = Graph.complete(n)
+			expect(graph.isSemiHamiltonian()).toBeFalsy()
+		})
+
+		test('complete 2', () => {
+			const graph = Graph.complete(2)
+			expect(graph.isSemiHamiltonian()).toBeTruthy()
+		})
+
+		test('path graph', () => {
+			const graph = new Graph(3, [
+				[0, 1],
+				[1, 2],
+			])
+			expect(graph.isSemiHamiltonian()).toBeTruthy()
+		})
+
+		test('no hamiltonian path', () => {
+			const graph = new Graph(4, [
+				[0, 1],
+				[0, 2],
+				[0, 3],
+			])
+			expect(graph.isSemiHamiltonian()).toBeFalsy()
+		})
+
+		test('not connected', () => {
+			const graph = new Graph(2)
+			expect(graph.isSemiHamiltonian()).toBeFalsy()
 		})
 	})
 
@@ -2285,6 +2534,55 @@ describe('graph', () => {
 				{ 0: 2, 1: 3, direct: true },
 			])
 			expect(graph.hasCycleEachNodes()).toBeFalsy()
+		})
+
+		test('cycle include path', () => {
+			const graph = new Graph(4, [
+				[0, 1],
+				[1, 2],
+				[2, 3],
+				[3, 1],
+			])
+			expect(graph.hasCycleEachNodes()).toBeTruthy()
+		})
+	})
+
+	describe('toUndirected', () => {
+		test('directed graph', () => {
+			const graph = new Graph(4, [
+				{ 0: 0, 1: 1, direct: true },
+				{ 0: 1, 1: 2, direct: true },
+				{ 0: 2, 1: 0, direct: true },
+				{ 0: 2, 1: 3, direct: true },
+			])
+
+			const undirectedGraph = graph.toUndirected()
+			expect(undirectedGraph.isUndirected()).toBeTruthy()
+			expect(undirectedGraph.getEdges(0, 1)).toHaveLength(1)
+			expect(undirectedGraph.getEdges(1, 2)).toHaveLength(1)
+			expect(undirectedGraph.getEdges(2, 0)).toHaveLength(1)
+			expect(undirectedGraph.getEdges(2, 3)).toHaveLength(1)
+		})
+	})
+
+	describe('toSimple', () => {
+		test('directed graph', () => {
+			const graph = new Graph(3, [
+				{ 0: 0, 1: 1, direct: true },
+				[1, 2],
+				{ 0: 2, 1: 0, direct: true },
+				[2, 0],
+				{ 0: 1, 1: 1, direct: true },
+			])
+
+			const undirectedGraph = graph.toSimple()
+			expect(undirectedGraph.isSimple()).toBeTruthy()
+			expect(undirectedGraph.getEdges(0, 1)).toHaveLength(1)
+			expect(undirectedGraph.getEdges(0, 1)[0].direct).toBeTruthy()
+			expect(undirectedGraph.getEdges(1, 2)).toHaveLength(1)
+			expect(undirectedGraph.getEdges(1, 2)[0].direct).toBeFalsy()
+			expect(undirectedGraph.getEdges(2, 0)).toHaveLength(1)
+			expect(undirectedGraph.getEdges(2, 0)[0].direct).toBeTruthy()
 		})
 	})
 
@@ -2491,6 +2789,33 @@ describe('graph', () => {
 		})
 	})
 
+	describe('line', () => {
+		test('default', () => {
+			const graph = new Graph(4, [
+				[0, 1],
+				[0, 2],
+				[3, 1],
+			])
+			const line = graph.line()
+			expect(line.order).toBe(graph.size)
+			expect(line.size).toBe(2)
+		})
+
+		test('edgeless', () => {
+			const graph = new Graph(7)
+			const line = graph.line()
+			expect(line.order).toBe(graph.size)
+			expect(line.size).toBe(0)
+		})
+
+		test('complete', () => {
+			const graph = Graph.complete(5)
+			const line = graph.line()
+			expect(line.order).toBe(graph.size)
+			expect(line.size).toBe(30)
+		})
+	})
+
 	describe('contraction', () => {
 		test('default', () => {
 			const graph = new Graph(4, [
@@ -2517,15 +2842,27 @@ describe('graph', () => {
 		})
 
 		test('a > b', () => {
-			const graph = new Graph(4, [
+			const graph = new Graph(3, [
+				[0, 1],
+				[0, 2],
+				[1, 2],
+			])
+			graph.contraction(2, 1)
+			expect(graph.order).toBe(2)
+			expect(graph.size).toBe(2)
+		})
+
+		test('decrease number', () => {
+			const graph = new Graph(5, [
 				[0, 1],
 				[0, 2],
 				[1, 2],
 				[2, 3],
+				[3, 4],
 			])
 			graph.contraction(2, 1)
-			expect(graph.order).toBe(3)
-			expect(graph.size).toBe(3)
+			expect(graph.order).toBe(4)
+			expect(graph.size).toBe(4)
 		})
 	})
 
@@ -2540,6 +2877,38 @@ describe('graph', () => {
 			graph.subdivision(1, 2)
 			expect(graph.order).toBe(5)
 			expect(graph.size).toBe(5)
+		})
+	})
+
+	describe('cleaving', () => {
+		test('default', () => {
+			const graph = new Graph(4, [
+				[0, 1],
+				[0, 2],
+				[1, 2],
+				[2, 3],
+			])
+			graph.cleaving(1)
+			expect(graph.order).toBe(5)
+			expect(graph.size).toBe(6)
+			expect(graph.getEdges(4, 0)).toHaveLength(1)
+			expect(graph.getEdges(4, 1)).toHaveLength(0)
+			expect(graph.getEdges(4, 2)).toHaveLength(1)
+			expect(graph.getEdges(4, 3)).toHaveLength(0)
+			expect(graph.getEdges(4, 4)).toHaveLength(0)
+		})
+
+		test('has loop', () => {
+			const graph = new Graph(2, [
+				[0, 1],
+				[0, 0],
+			])
+			graph.cleaving(0)
+			expect(graph.order).toBe(3)
+			expect(graph.size).toBe(4)
+			expect(graph.getEdges(2, 0)).toHaveLength(0)
+			expect(graph.getEdges(2, 1)).toHaveLength(1)
+			expect(graph.getEdges(2, 2)).toHaveLength(1)
 		})
 	})
 
@@ -2572,6 +2941,26 @@ describe('graph', () => {
 			expect(g1.getEdges(0, 3)).toHaveLength(1)
 			expect(g1.getEdges(1, 2)).toHaveLength(1)
 			expect(g1.getEdges(1, 3)).toHaveLength(1)
+			expect(g1.getEdges(2, 3)).toHaveLength(1)
+		})
+
+		test('index 0', () => {
+			const g1 = new Graph(3, [
+				[0, 1],
+				[1, 2],
+			])
+			const g2 = new Graph(2, [
+				[0, 1],
+				[1, 0],
+			])
+			g1.substitution(1, g2)
+			expect(g1.order).toBe(4)
+			expect(g1.size).toBe(6)
+			expect(g1.getEdges(0, 1)).toHaveLength(1)
+			expect(g1.getEdges(0, 2)).toHaveLength(0)
+			expect(g1.getEdges(0, 3)).toHaveLength(1)
+			expect(g1.getEdges(1, 2)).toHaveLength(1)
+			expect(g1.getEdges(1, 3)).toHaveLength(2)
 			expect(g1.getEdges(2, 3)).toHaveLength(1)
 		})
 
@@ -2649,6 +3038,56 @@ describe('graph', () => {
 				}
 			}
 		})
+
+		test('with value', () => {
+			const g1 = new Graph(
+				['a', 'b', 'c'],
+				[
+					{ 0: 0, 1: 1, value: 'x' },
+					{ 0: 1, 1: 2, value: 'y' },
+				]
+			)
+			const g2 = new Graph(['d', 'e'], [{ 0: 0, 1: 1, value: 'z' }])
+			const cp = g1.cartesianProduct(g2)
+			expect(cp.order).toBe(g1.order * g2.order)
+			for (let i = 0; i < g1.order; i++) {
+				for (let j = 0; j < g2.order; j++) {
+					expect(cp._nodes[i * g2.order + j]).toEqual([g1._nodes[i], g2._nodes[j]])
+				}
+			}
+			expect(cp.size).toBe(g1.order * g2.size + g2.order * g1.size)
+			for (let i = 0; i < g1.order; i++) {
+				for (let j = 0; j < g2.order; j++) {
+					const st = i + j * g1.order
+					for (let s = 0; s < g1.order; s++) {
+						for (let t = 0; t < g2.order; t++) {
+							const ed = s + t * g1.order
+							const es = []
+							for (const e of cp.edges) {
+								if ((e[0] === st && e[1] === ed) || (!e.direct && e[0] === ed && e[1] === st)) {
+									es.push(e)
+								}
+							}
+							expect(es).toHaveLength(
+								(i === s && g2.getEdges(j, t).length > 0) || (j === t && g1.getEdges(i, s).length > 0)
+									? 1
+									: 0
+							)
+						}
+					}
+				}
+			}
+			for (const edge of g1.edges) {
+				for (let i = 0; i < g2.order; i++) {
+					expect(cp.getEdges(edge[0] + i * g1.order, edge[1] + i * g1.order)[0].value).toBe(edge.value)
+				}
+			}
+			for (const edge of g2.edges) {
+				for (let i = 0; i < g1.order; i++) {
+					expect(cp.getEdges(i + edge[0] * g1.order, i + edge[1] * g1.order)[0].value).toBe(edge.value)
+				}
+			}
+		})
 	})
 
 	describe('tensorProduct', () => {
@@ -2680,6 +3119,57 @@ describe('graph', () => {
 					}
 				}
 			}
+		})
+
+		test('with values', () => {
+			const g1 = new Graph(
+				['a', 'b', 'c'],
+				[
+					{ 0: 0, 1: 1, value: 'x' },
+					{ 0: 1, 1: 2, value: 'y' },
+				]
+			)
+			const g2 = new Graph(['d', 'e'], [{ 0: 0, 1: 1, value: 'z' }])
+			const cp = g1.tensorProduct(g2)
+			expect(cp.order).toBe(g1.order * g2.order)
+			for (let i = 0; i < g1.order; i++) {
+				for (let j = 0; j < g2.order; j++) {
+					expect(cp._nodes[i * g2.order + j]).toEqual([g1._nodes[i], g2._nodes[j]])
+				}
+			}
+			expect(cp.size).toBe(g1.size * g2.size * 2)
+			for (let i = 0; i < g1.order; i++) {
+				for (let j = 0; j < g2.order; j++) {
+					const st = i + j * g1.order
+					for (let s = 0; s < g1.order; s++) {
+						for (let t = 0; t < g2.order; t++) {
+							const ed = s + t * g1.order
+							const es = []
+							for (const e of cp.edges) {
+								if ((e[0] === st && e[1] === ed) || (!e.direct && e[0] === ed && e[1] === st)) {
+									es.push(e)
+								}
+							}
+							expect(es).toHaveLength(
+								g1.getEdges(i, s).length > 0 && g2.getEdges(j, t).length > 0 ? 1 : 0
+							)
+						}
+					}
+				}
+			}
+			expect(cp.getEdges(0, 4)[0].value).toEqual(['x', 'z'])
+			expect(cp.getEdges(1, 3)[0].value).toEqual(['x', 'z'])
+			expect(cp.getEdges(1, 5)[0].value).toEqual(['y', 'z'])
+			expect(cp.getEdges(2, 4)[0].value).toEqual(['y', 'z'])
+		})
+
+		test('direct', () => {
+			const g1 = new Graph(3, [[0, 1], { 0: 1, 1: 2, direct: true }])
+			const g2 = new Graph(2, [{ 0: 0, 1: 1, direct: true }])
+			const cp = g1.tensorProduct(g2)
+			expect(cp.order).toBe(g1.order * g2.order)
+			expect(cp.size).toBe(1)
+			expect(cp.getEdges(1, 5)).toHaveLength(1)
 		})
 	})
 
@@ -2717,6 +3207,81 @@ describe('graph', () => {
 				}
 			}
 		})
+
+		test('with values', () => {
+			const g1 = new Graph(
+				['a', 'b', 'c'],
+				[
+					{ 0: 0, 1: 1, value: 'x' },
+					{ 0: 1, 1: 2, value: 'y' },
+				]
+			)
+			const g2 = new Graph(['d', 'e'], [{ 0: 0, 1: 1, value: 'z' }])
+			const cp = g1.strongProduct(g2)
+			expect(cp.order).toBe(g1.order * g2.order)
+			for (let i = 0; i < g1.order; i++) {
+				for (let j = 0; j < g2.order; j++) {
+					expect(cp._nodes[i * g2.order + j]).toEqual([g1._nodes[i], g2._nodes[j]])
+				}
+			}
+			expect(cp.size).toBe(g1.order * g2.size + g2.order * g1.size + g1.size * g2.size * 2)
+			for (let i = 0; i < g1.order; i++) {
+				for (let j = 0; j < g2.order; j++) {
+					const st = i + j * g1.order
+					for (let s = 0; s < g1.order; s++) {
+						for (let t = 0; t < g2.order; t++) {
+							const ed = s + t * g1.order
+							const es = []
+							for (const e of cp.edges) {
+								if ((e[0] === st && e[1] === ed) || (!e.direct && e[0] === ed && e[1] === st)) {
+									es.push(e)
+								}
+							}
+							expect(es).toHaveLength(
+								(i === s && g2.getEdges(j, t).length > 0) ||
+									(j === t && g1.getEdges(i, s).length > 0) ||
+									(g1.getEdges(i, s).length > 0 && g2.getEdges(j, t).length > 0)
+									? 1
+									: 0
+							)
+						}
+					}
+				}
+			}
+			for (const edge of g1.edges) {
+				for (let i = 0; i < g2.order; i++) {
+					expect(cp.getEdges(edge[0] + i * g1.order, edge[1] + i * g1.order)[0].value).toBe(edge.value)
+				}
+			}
+			for (const edge of g2.edges) {
+				for (let i = 0; i < g1.order; i++) {
+					expect(cp.getEdges(i + edge[0] * g1.order, i + edge[1] * g1.order)[0].value).toBe(edge.value)
+				}
+			}
+			expect(cp.getEdges(0, 4)[0].value).toEqual(['x', 'z'])
+			expect(cp.getEdges(1, 3)[0].value).toEqual(['x', 'z'])
+			expect(cp.getEdges(1, 5)[0].value).toEqual(['y', 'z'])
+			expect(cp.getEdges(2, 4)[0].value).toEqual(['y', 'z'])
+		})
+
+		test('direct', () => {
+			const g1 = new Graph(3, [[0, 1], { 0: 1, 1: 2, direct: true }])
+			const g2 = new Graph(2, [{ 0: 0, 1: 1, direct: true }])
+			const cp = g1.strongProduct(g2)
+			expect(cp.order).toBe(g1.order * g2.order)
+			expect(cp.size).toBe(8)
+			for (const edge of g1.edges) {
+				for (let i = 0; i < g2.order; i++) {
+					expect(cp.getEdges(edge[0] + i * g1.order, edge[1] + i * g1.order)).toHaveLength(1)
+				}
+			}
+			for (const edge of g2.edges) {
+				for (let i = 0; i < g1.order; i++) {
+					expect(cp.getEdges(i + edge[0] * g1.order, i + edge[1] * g1.order)).toHaveLength(1)
+				}
+			}
+			expect(cp.getEdges(1, 5)).toHaveLength(1)
+		})
 	})
 
 	describe('lexicographicProduct', () => {
@@ -2728,6 +3293,44 @@ describe('graph', () => {
 			const g2 = new Graph(2, [[0, 1]])
 			const cp = g1.lexicographicProduct(g2)
 			expect(cp.order).toBe(g1.order * g2.order)
+			expect(cp.size).toBe(g1.size * g2.order ** 2 + g1.order * g2.size)
+			for (let i = 0; i < g1.order; i++) {
+				for (let j = 0; j < g2.order; j++) {
+					const st = i + j * g1.order
+					for (let s = 0; s < g1.order; s++) {
+						for (let t = 0; t < g2.order; t++) {
+							const ed = s + t * g1.order
+							const es = []
+							for (const e of cp.edges) {
+								if ((e[0] === st && e[1] === ed) || (!e.direct && e[0] === ed && e[1] === st)) {
+									es.push(e)
+								}
+							}
+							expect(es).toHaveLength(
+								g1.getEdges(i, s).length > 0 || (i === s && g2.getEdges(j, t).length > 0) ? 1 : 0
+							)
+						}
+					}
+				}
+			}
+		})
+
+		test('with values', () => {
+			const g1 = new Graph(
+				['a', 'b', 'c'],
+				[
+					{ 0: 0, 1: 1, value: 'x' },
+					{ 0: 1, 1: 2, value: 'y' },
+				]
+			)
+			const g2 = new Graph(['d', 'e'], [{ 0: 0, 1: 1, value: 'z' }])
+			const cp = g1.lexicographicProduct(g2)
+			expect(cp.order).toBe(g1.order * g2.order)
+			for (let i = 0; i < g1.order; i++) {
+				for (let j = 0; j < g2.order; j++) {
+					expect(cp._nodes[i * g2.order + j]).toEqual([g1._nodes[i], g2._nodes[j]])
+				}
+			}
 			expect(cp.size).toBe(g1.size * g2.order ** 2 + g1.order * g2.size)
 			for (let i = 0; i < g1.order; i++) {
 				for (let j = 0; j < g2.order; j++) {
@@ -2806,7 +3409,7 @@ describe('graph', () => {
 	describe('shortestPathBreadthFirstSearch', () => {
 		test('default', () => {
 			const graph = new Graph(4, [
-				[0, 1],
+				[1, 0],
 				[0, 2],
 				[1, 2],
 				[1, 3],
@@ -2818,12 +3421,22 @@ describe('graph', () => {
 			expect(p[2]).toEqual({ length: 1, prev: 0, path: [0, 2] })
 			expect(p[3]).toEqual({ length: 2, prev: 1, path: [0, 1, 3] })
 		})
+
+		test('has negative weight', () => {
+			const graph = new Graph(4, [[0, 1], { 0: 0, 1: 2, value: -1 }, [1, 2], [1, 3]])
+			const p = graph.shortestPathBreadthFirstSearch(0)
+			expect(p).toHaveLength(4)
+			expect(p[0]).toEqual({ length: 0, prev: null, path: [0] })
+			expect(p[1]).toEqual({ length: 1, prev: 0, path: [0, 1] })
+			expect(p[2]).toEqual({ length: 2, prev: 1, path: [0, 1, 2] })
+			expect(p[3]).toEqual({ length: 2, prev: 1, path: [0, 1, 3] })
+		})
 	})
 
 	describe('shortestPathDijkstra', () => {
 		test('default', () => {
 			const graph = new Graph(4, [
-				[0, 1],
+				[1, 0],
 				[0, 2],
 				[1, 2],
 				[1, 3],
@@ -2833,6 +3446,16 @@ describe('graph', () => {
 			expect(p[0]).toEqual({ length: 0, prev: null, path: [0] })
 			expect(p[1]).toEqual({ length: 1, prev: 0, path: [0, 1] })
 			expect(p[2]).toEqual({ length: 1, prev: 0, path: [0, 2] })
+			expect(p[3]).toEqual({ length: 2, prev: 1, path: [0, 1, 3] })
+		})
+
+		test('has negative weight', () => {
+			const graph = new Graph(4, [[0, 1], { 0: 0, 1: 2, value: -1 }, [1, 2], [1, 3]])
+			const p = graph.shortestPathDijkstra(0)
+			expect(p).toHaveLength(4)
+			expect(p[0]).toEqual({ length: 0, prev: null, path: [0] })
+			expect(p[1]).toEqual({ length: 1, prev: 0, path: [0, 1] })
+			expect(p[2]).toEqual({ length: 2, prev: 1, path: [0, 1, 2] })
 			expect(p[3]).toEqual({ length: 2, prev: 1, path: [0, 1, 3] })
 		})
 	})
@@ -2948,6 +3571,123 @@ describe('graph', () => {
 			expect(tree.order).toBe(4)
 			expect(tree.size).toBe(3)
 			expect(tree.isTree()).toBeTruthy()
+		})
+	})
+
+	describe('hamiltonianPath', () => {
+		test.each([1, 2, 3, 4, 5, 6, 7])('complete %d', n => {
+			const graph = Graph.complete(n)
+			const path = graph.hamiltonianPath()
+			expect(path).toHaveLength(Array.from({ length: n }, (_, i) => i + 1).reduce((s, v) => s * v, 1))
+		})
+
+		test.each([5])('complete %d with from', n => {
+			const graph = Graph.complete(n)
+			const path = graph.hamiltonianPath(0)
+			expect(path).toHaveLength(Array.from({ length: n - 1 }, (_, i) => i + 1).reduce((s, v) => s * v, 1))
+			for (const p of path) {
+				expect(p[0]).toBe(0)
+			}
+		})
+
+		test('path graph', () => {
+			const graph = new Graph(3, [
+				[0, 1],
+				[1, 2],
+			])
+			const path = graph.hamiltonianPathDynamicProgramming()
+			expect(path).toHaveLength(2)
+		})
+
+		test('not connected', () => {
+			const graph = new Graph(5, [
+				[0, 1],
+				[2, 3],
+				[3, 4],
+				[4, 2],
+			])
+			const path = graph.hamiltonianPath()
+			expect(path).toHaveLength(0)
+		})
+	})
+
+	describe('hamiltonianPathDynamicProgramming', () => {
+		test.each([1, 2, 3, 4, 5])('complete %d', n => {
+			const graph = Graph.complete(n)
+			const path = graph.hamiltonianPathDynamicProgramming()
+			expect(path).toHaveLength(Array.from({ length: n }, (_, i) => i + 1).reduce((s, v) => s * v, 1))
+		})
+
+		test.each([5])('complete %d with from', n => {
+			const graph = Graph.complete(n)
+			const path = graph.hamiltonianPathDynamicProgramming(0)
+			expect(path).toHaveLength(Array.from({ length: n - 1 }, (_, i) => i + 1).reduce((s, v) => s * v, 1))
+			for (const p of path) {
+				expect(p[0]).toBe(0)
+			}
+		})
+
+		test('path graph', () => {
+			const graph = new Graph(3, [
+				[0, 1],
+				[1, 2],
+			])
+			const path = graph.hamiltonianPathDynamicProgramming()
+			expect(path).toHaveLength(2)
+		})
+
+		test('not connected', () => {
+			const graph = new Graph(5, [
+				[0, 1],
+				[2, 3],
+				[3, 4],
+				[4, 2],
+			])
+			const path = graph.hamiltonianPathDynamicProgramming()
+			expect(path).toHaveLength(0)
+		})
+	})
+
+	describe('hamiltonianCycle', () => {
+		test.each([1, 3, 4, 5, 6, 7])('complete %d', n => {
+			const graph = Graph.complete(n)
+			const path = graph.hamiltonianCycle()
+			expect(path).toHaveLength(Array.from({ length: n }, (_, i) => i + 1).reduce((s, v) => s * v, 1))
+		})
+
+		test('complete 2', () => {
+			const graph = Graph.complete(2)
+			const path = graph.hamiltonianCycle()
+			expect(path).toHaveLength(0)
+		})
+
+		test('multiedge 2', () => {
+			const graph = new Graph(2, [
+				[0, 1],
+				[0, 1],
+			])
+			const path = graph.hamiltonianCycle()
+			expect(path).toHaveLength(2)
+		})
+
+		test('path graph', () => {
+			const graph = new Graph(3, [
+				[0, 1],
+				[1, 2],
+			])
+			const path = graph.hamiltonianCycle()
+			expect(path).toHaveLength(0)
+		})
+
+		test('not connected', () => {
+			const graph = new Graph(5, [
+				[0, 1],
+				[2, 3],
+				[3, 4],
+				[4, 2],
+			])
+			const path = graph.hamiltonianCycle()
+			expect(path).toHaveLength(0)
 		})
 	})
 


### PR DESCRIPTION
Resolve #672 .

Changes proposed in this pull request:
- Add `from` and `to` properties in edge class
- Improve some method checking "already checked"
- Improve `chromaticIndex`
- Add `clearNodes`, `clearEdges`, `isEulerian`, `isSemiEulerian`, `isHamiltonian`, `isSemiHamiltonian`, `toUndirected`, `toSimple`, `line`, `cleaving`, `hamiltonianPath`, `hamiltonianPathDynamicProgramming` and `hamiltonianCycle` methods
- Improve `getEdges` to set detail condition
- Fix `hasCycleEachNodes`, `subdivision`, `cartesianProduct`, `tensorProduct`, `strongProduct` and `lexicographicProduct`