### PR TITLE
Add maxIteration argument for some eigenValues calculation methods

### DIFF
--- a/lib/util/matrix.js
+++ b/lib/util/matrix.js
@@ -4220,9 +4220,10 @@ export default class Matrix {
 	/**
 	 * Returns eigenvalues by LU decomposition.
 	 *
+	 * @param {number} [maxIteration=1.0e5] Maximum iteration
 	 * @returns {number[]} Eigenvalues
 	 */
-	eigenValuesLR() {
+	eigenValuesLR(maxIteration = 1.0e5) {
 		if (!this.isSquare()) {
 			throw new MatrixException('Eigen values only define square matrix.', this)
 		}
@@ -4230,7 +4231,7 @@ export default class Matrix {
 		let a = this
 		const n = a.rows
 		const tol = 1.0e-15
-		let maxCount = 1.0e5
+		let maxCount = maxIteration
 		while (maxCount-- > 0) {
 			const [l, u] = a.lu()
 			a = u.dot(l)
@@ -4253,9 +4254,10 @@ export default class Matrix {
 	/**
 	 * Returns eigenvalues by QR decomposition.
 	 *
+	 * @param {number} [maxIteration=1.0e6] Maximum iteration
 	 * @returns {number[]} Eigenvalues
 	 */
-	eigenValuesQR() {
+	eigenValuesQR(maxIteration = 1.0e6) {
 		if (!this.isSquare()) {
 			throw new MatrixException('Eigen values only define square matrix.', this)
 		}
@@ -4264,7 +4266,7 @@ export default class Matrix {
 		const ev = []
 		const tol = 1.0e-8
 		for (let n = a.rows; n > 2; n--) {
-			let maxCount = 1.0e6
+			let maxCount = maxIteration
 			while (1) {
 				const am = a.block(n - 2, n - 2).eigenValues()
 				if (isNaN(am[0])) {
@@ -4383,9 +4385,10 @@ export default class Matrix {
 	/**
 	 * Returns the maximum eigenvalue and its eigenvector.
 	 *
+	 * @param {number} [maxIteration=1.0e4] Maximum iteration
 	 * @returns {[number, Matrix]} Maximum eigenvalue and its eigenvector
 	 */
-	eigenPowerIteration() {
+	eigenPowerIteration(maxIteration = 1.0e4) {
 		if (!this.isSquare()) {
 			throw new MatrixException('Eigen vectors only define square matrix.', this)
 		}
@@ -4395,7 +4398,7 @@ export default class Matrix {
 		let px = Matrix.randn(n, 1)
 		px.div(px.norm())
 		let pl = Infinity
-		let maxCount = 1.0e4
+		let maxCount = maxIteration
 		while (maxCount-- > 0) {
 			const x = this.dot(px)
 			let lnum = 0,
@@ -4420,9 +4423,10 @@ export default class Matrix {
 	 * Returns the nearest eigenvalue and its eigenvector to the specified value.
 	 *
 	 * @param {number} [ev=0.0] Target value
+	 * @param {number} [maxIteration=1.0e4] Maximum iteration
 	 * @returns {[number, Matrix]} Eigenvalue and eigenvector
 	 */
-	eigenInverseIteration(ev = 0.0) {
+	eigenInverseIteration(ev = 0.0, maxIteration = 1.0e4) {
 		if (!this.isSquare()) {
 			throw new MatrixException('Eigen vectors only define square matrix.', this)
 		}
@@ -4437,7 +4441,7 @@ export default class Matrix {
 		let py = Matrix.randn(n, 1)
 		py.div(py.norm())
 		let pl = Infinity
-		let maxCount = 1.0e4
+		let maxCount = maxIteration
 		while (maxCount-- > 0) {
 			const y = a.dot(py)
 			let lnum = 0,

--- a/tests/lib/util/matrix.test.js
+++ b/tests/lib/util/matrix.test.js
@@ -5469,7 +5469,9 @@ describe('Matrix', () => {
 		test('fail neg value', () => {
 			const mat = Matrix.randn(3, 3)
 			mat.set(0, 0, -0.1)
-			expect(() => mat.balancingSinkhornKnopp()).toThrow('Doubly stochastic matrix only calculate for non negative matrix.')
+			expect(() => mat.balancingSinkhornKnopp()).toThrow(
+				'Doubly stochastic matrix only calculate for non negative matrix.'
+			)
 		})
 
 		test.each([
@@ -5477,7 +5479,9 @@ describe('Matrix', () => {
 			[3, 2],
 		])('fail(%i, %i)', (r, c) => {
 			const mat = Matrix.randn(r, c)
-			expect(() => mat.balancingSinkhornKnopp()).toThrow('Doubly stochastic matrix only defined for square matrix.')
+			expect(() => mat.balancingSinkhornKnopp()).toThrow(
+				'Doubly stochastic matrix only defined for square matrix.'
+			)
 		})
 	})
 
@@ -6653,13 +6657,13 @@ describe('Matrix', () => {
 			expect(() => mat.eigenValuesQR()).toThrow('Eigen values only define square matrix.')
 		})
 
-		test.only('iteration not converged', () => {
+		test('iteration not converged', () => {
 			const mat = new Matrix(3, 3, [
 				[-0.3, -0.4, 1.7],
 				[-0.2, -1.8, -0.8],
 				[-0.9, 0.5, -0.5],
 			])
-			expect(() => mat.eigenValuesQR()).toThrow('eigenValuesQR not converged.')
+			expect(() => mat.eigenValuesQR(1)).toThrow('eigenValuesQR not converged.')
 		})
 	})
 
@@ -6782,7 +6786,7 @@ describe('Matrix', () => {
 				[-1, -2],
 				[2, -2],
 			])
-			expect(() => mat.eigenPowerIteration()).toThrow('eigenPowerIteration not converged.')
+			expect(() => mat.eigenPowerIteration(1)).toThrow('eigenPowerIteration not converged.')
 		})
 	})
 
@@ -6856,7 +6860,7 @@ describe('Matrix', () => {
 				[-1, -2],
 				[2, -2],
 			])
-			expect(() => mat.eigenInverseIteration()).toThrow('eigenInverseIteration not converged.')
+			expect(() => mat.eigenInverseIteration(0, 1)).toThrow('eigenInverseIteration not converged.')
 		})
 	})
 })


### PR DESCRIPTION
Resolve #725 .

Changes proposed in this pull request:
- Add maxIteration argument for some eigenValues calculation methods
