### PR TITLE
Simplify the gradient calculation for ordered logistic regression

### DIFF
--- a/lib/model/ordered_logistic.js
+++ b/lib/model/ordered_logistic.js
@@ -50,7 +50,7 @@ export default class OrderedLogisticRegression {
 			dt[k + 1] -= (pk1 * (1 - pk1)) / (pk0 - pk1)
 
 			const dwi = x.row(i).t
-			dwi.mult((pk1 * (1 - pk1) - pk0 * (1 - pk0)) / (pk0 - pk1))
+			dwi.mult(pk0 + pk1 - 1)
 			dw.add(dwi)
 		}
 		dw.mult(this._a / y.length)


### PR DESCRIPTION
Resolve #748 .

Changes proposed in this pull request:
- Simplify the gradient calculation for ordered logistic regression
