### PR TITLE
Set the default predicted value at the beginning of the fit in CLUES

### DIFF
--- a/lib/model/clues.js
+++ b/lib/model/clues.js
@@ -40,7 +40,7 @@ export default class CLUES {
 		const T = Math.max(1, Math.round(this._alpha * n))
 		let smax = -Infinity
 
-		let clusters_star = null
+		let clusters_star = Array(n).fill(0)
 		let g_star = Infinity
 		let y = datas
 		for (let t = 1; t <= T; t++) {

--- a/tests/lib/model/clues.test.js
+++ b/tests/lib/model/clues.test.js
@@ -42,4 +42,17 @@ describe('clustering', () => {
 		const ri = randIndex(y, t)
 		expect(ri).toBeGreaterThan(0.9)
 	})
+
+	test('small data', () => {
+		const model = new CLUES(0.8)
+		const x = Matrix.random(5, 2, -0.1, 0.1).toArray()
+
+		model.fit(x)
+		const y = model.predict()
+		expect(y).toHaveLength(x.length)
+		expect(model.size).toBe(1)
+		for (let i = 0; i < y.length; i++) {
+			expect(y[i]).toBe(0)
+		}
+	})
 })


### PR DESCRIPTION
Resolve #754 .

Changes proposed in this pull request:
- Set the default predicted value at the beginning of the fit in CLUES.
