### PR TITLE
Use object literals instead of switch statements in some constructors

### DIFF
--- a/lib/model/agglomerative.js
+++ b/lib/model/agglomerative.js
@@ -1,3 +1,9 @@
+const metrics = {
+	euclid: (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0)),
+	manhattan: (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0),
+	chebyshev: (a, b) => a.reduce((s, v, i) => Math.max(s, Math.abs(v - b[i])), -Infinity),
+}
+
 /**
  * @typedef {object} AgglomerativeClusterNode
  * @property {number[]} [point] Data point of leaf node
@@ -22,17 +28,7 @@ class AgglomerativeClustering {
 		if (typeof this._metric === 'function') {
 			this._d = this._metric
 		} else {
-			switch (this._metric) {
-				case 'euclid':
-					this._d = (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0))
-					break
-				case 'manhattan':
-					this._d = (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0)
-					break
-				case 'chebyshev':
-					this._d = (a, b) => a.reduce((s, v, i) => Math.max(s, Math.abs(v - b[i])), -Infinity)
-					break
-			}
+			this._d = metrics[this._metric]
 		}
 	}
 

--- a/lib/model/bogd.js
+++ b/lib/model/bogd.js
@@ -1,3 +1,14 @@
+const kernels = {
+	gaussian:
+		({ s = 1 }) =>
+		(a, b) =>
+			Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / s ** 2),
+	polynomial:
+		({ d = 2 }) =>
+		(a, b) =>
+			(1 + a.reduce((s, v, i) => s + v * b[i])) ** d,
+}
+
 /**
  * Bounded Online Gradient Descent
  */
@@ -34,17 +45,7 @@ export default class BOGD {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			switch (kernel.name) {
-				case 'gaussian':
-					this._s = kernel.s ?? 1
-					this._kernel = (a, b) =>
-						Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / this._s ** 2)
-					break
-				case 'polynomial':
-					this._d = kernel.d ?? 2
-					this._kernel = (a, b) => (1 + a.reduce((s, v, i) => s + v * b[i])) ** this._d
-					break
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 
 		if (loss === 'zero_one') {

--- a/lib/model/bpa.js
+++ b/lib/model/bpa.js
@@ -1,5 +1,16 @@
 import Matrix from '../util/matrix.js'
 
+const kernels = {
+	gaussian:
+		({ s = 1 }) =>
+		(a, b) =>
+			Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / s ** 2),
+	polynomial:
+		({ d = 2 }) =>
+		(a, b) =>
+			(1 + a.reduce((s, v, i) => s + v * b[i])) ** d,
+}
+
 /**
  * Budgeted online Passive-Aggressive
  */
@@ -22,17 +33,7 @@ export default class BPA {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			switch (kernel.name) {
-				case 'gaussian':
-					this._s = kernel.s ?? 1
-					this._kernel = (a, b) =>
-						Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / this._s ** 2)
-					break
-				case 'polynomial':
-					this._d = kernel.d ?? 2
-					this._kernel = (a, b) => (1 + a.reduce((s, v, i) => s + v * b[i])) ** this._d
-					break
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 
 		this._sv = []

--- a/lib/model/bsgd.js
+++ b/lib/model/bsgd.js
@@ -1,5 +1,16 @@
 import Matrix from '../util/matrix.js'
 
+const kernels = {
+	gaussian:
+		({ s = 1 }) =>
+		(a, b) =>
+			Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / s ** 2),
+	polynomial:
+		({ d = 2 }) =>
+		(a, b) =>
+			(1 + a.reduce((s, v, i) => s + v * b[i])) ** d,
+}
+
 /**
  * Budgeted Stochastic Gradient Descent
  */
@@ -24,17 +35,7 @@ export default class BSGD {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			switch (kernel.name) {
-				case 'gaussian':
-					this._s = kernel.s ?? 1
-					this._kernel = (a, b) =>
-						Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / this._s ** 2)
-					break
-				case 'polynomial':
-					this._d = kernel.d ?? 2
-					this._kernel = (a, b) => (1 + a.reduce((s, v, i) => s + v * b[i])) ** this._d
-					break
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 
 		this._sv = []
@@ -209,17 +210,7 @@ export class MulticlassBSGD {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			switch (kernel.name) {
-				case 'gaussian':
-					this._s = kernel.s ?? 1
-					this._kernel = (a, b) =>
-						Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / this._s ** 2)
-					break
-				case 'polynomial':
-					this._d = kernel.d ?? 2
-					this._kernel = (a, b) => (1 + a.reduce((s, v, i) => s + v * b[i])) ** this._d
-					break
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 
 		this._classes = []

--- a/lib/model/coll.js
+++ b/lib/model/coll.js
@@ -1,5 +1,16 @@
 import Matrix from '../util/matrix.js'
 
+const kernels = {
+	gaussian:
+		({ s = 1 }) =>
+		(a, b) =>
+			Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / s ** 2),
+	polynomial:
+		({ d = 2 }) =>
+		(a, b) =>
+			(1 + a.reduce((s, v, i) => s + v * b[i])) ** d,
+}
+
 /**
  * Conscience on-line learning
  */
@@ -20,17 +31,7 @@ export default class COLL {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			switch (kernel.name) {
-				case 'gaussian':
-					this._s = kernel.s ?? 1
-					this._kernel = (a, b) =>
-						Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / this._s ** 2)
-					break
-				case 'polynomial':
-					this._d = kernel.d ?? 2
-					this._kernel = (a, b) => (1 + a.reduce((s, v, i) => s + v * b[i])) ** this._d
-					break
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 	}
 

--- a/lib/model/dbscan.js
+++ b/lib/model/dbscan.js
@@ -1,3 +1,9 @@
+const metrics = {
+	euclid: (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0)),
+	manhattan: (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0),
+	chebyshev: (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i]))),
+}
+
 /**
  * Density-based spatial clustering of applications with noise
  */
@@ -16,17 +22,7 @@ export default class DBSCAN {
 		if (typeof this._metric === 'function') {
 			this._d = this._metric
 		} else {
-			switch (this._metric) {
-				case 'euclid':
-					this._d = (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0))
-					break
-				case 'manhattan':
-					this._d = (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0)
-					break
-				case 'chebyshev':
-					this._d = (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i])))
-					break
-			}
+			this._d = metrics[this._metric]
 		}
 	}
 

--- a/lib/model/denclue.js
+++ b/lib/model/denclue.js
@@ -1,3 +1,10 @@
+const kernels = {
+	gaussian: u => {
+		const d = u.length
+		return Math.exp(-u.reduce((s, v) => s + v ** 2, 0) / 2) / (2 * Math.PI) ** (d / 2)
+	},
+}
+
 /**
  * DENsity CLUstering
  */
@@ -20,10 +27,7 @@ export default class DENCLUE {
 		if (typeof kernel === 'function') {
 			this._kernel = kernel
 		} else if (kernel === 'gaussian' || kernel.name === 'gaussian') {
-			this._kernel = u => {
-				const d = u.length
-				return Math.exp(-u.reduce((s, v) => s + v ** 2, 0) / 2) / (2 * Math.PI) ** (d / 2)
-			}
+			this._kernel = kernels.gaussian
 		}
 	}
 

--- a/lib/model/diffusion_map.js
+++ b/lib/model/diffusion_map.js
@@ -1,5 +1,9 @@
 import Matrix from '../util/matrix.js'
 
+const kernels = {
+	gaussian: (x, y) => Math.exp(-x.reduce((s, v, i) => s + (v - y[i]) ** 2, 0) / 2),
+}
+
 /**
  * Diffusion map
  */
@@ -17,7 +21,7 @@ export default class DiffusionMap {
 		if (typeof kernel === 'function') {
 			this._k = kernel
 		} else if (kernel === 'gaussian' || kernel.name === 'gaussian') {
-			this._k = (x, y) => Math.exp(-x.reduce((s, v, i) => s + (v - y[i]) ** 2, 0) / 2)
+			this._k = kernels.gaussian
 		}
 	}
 

--- a/lib/model/enan.js
+++ b/lib/model/enan.js
@@ -1,3 +1,16 @@
+const metrics = {
+	euclid: () => (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0)),
+	manhattan: () => (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0),
+	chebyshev: () => (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i]))),
+	minkowski:
+		({ p = 2 } = {}) =>
+		(a, b) =>
+			Math.pow(
+				a.reduce((s, v, i) => s + (v - b[i]) ** p, 0),
+				1 / p
+			),
+}
+
 /**
  * Extended Natural Neighbor
  */
@@ -15,25 +28,7 @@ export default class ENaN {
 		if (typeof this._metric === 'function') {
 			this._d = this._metric
 		} else {
-			switch (this._metric) {
-				case 'euclid':
-					this._d = (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0))
-					break
-				case 'manhattan':
-					this._d = (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0)
-					break
-				case 'chebyshev':
-					this._d = (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i])))
-					break
-				case 'minkowski':
-					this._dp = 2
-					this._d = (a, b) =>
-						Math.pow(
-							a.reduce((s, v, i) => s + (v - b[i]) ** this._dp, 0),
-							1 / this._dp
-						)
-					break
-			}
+			this._d = metrics[this._metric]()
 		}
 	}
 

--- a/lib/model/enn.js
+++ b/lib/model/enn.js
@@ -1,3 +1,16 @@
+const metrics = {
+	euclid: () => (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0)),
+	manhattan: () => (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0),
+	chebyshev: () => (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i]))),
+	minkowski:
+		({ p = 2 } = {}) =>
+		(a, b) =>
+			Math.pow(
+				a.reduce((s, v, i) => s + (v - b[i]) ** p, 0),
+				1 / p
+			),
+}
+
 /**
  * Extended Nearest Neighbor
  */
@@ -18,25 +31,7 @@ export default class ENN {
 		if (typeof this._metric === 'function') {
 			this._d = this._metric
 		} else {
-			switch (this._metric) {
-				case 'euclid':
-					this._d = (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0))
-					break
-				case 'manhattan':
-					this._d = (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0)
-					break
-				case 'chebyshev':
-					this._d = (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i])))
-					break
-				case 'minkowski':
-					this._dp = 2
-					this._d = (a, b) =>
-						Math.pow(
-							a.reduce((s, v, i) => s + (v - b[i]) ** this._dp, 0),
-							1 / this._dp
-						)
-					break
-			}
+			this._d = metrics[this._metric]()
 		}
 	}
 

--- a/lib/model/forgetron.js
+++ b/lib/model/forgetron.js
@@ -1,3 +1,14 @@
+const kernels = {
+	gaussian:
+		({ s = 1 }) =>
+		(a, b) =>
+			Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / s ** 2),
+	polynomial:
+		({ d = 2 }) =>
+		(a, b) =>
+			(1 + a.reduce((s, v, i) => s + v * b[i])) ** d,
+}
+
 /**
  * Forgetron
  */
@@ -19,17 +30,7 @@ export default class Forgetron {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			switch (kernel.name) {
-				case 'gaussian':
-					this._s = kernel.s ?? 1
-					this._kernel = (a, b) =>
-						Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / this._s ** 2)
-					break
-				case 'polynomial':
-					this._d = kernel.d ?? 2
-					this._kernel = (a, b) => (1 + a.reduce((s, v, i) => s + v * b[i])) ** this._d
-					break
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 
 		this._i = []

--- a/lib/model/hdbscan.js
+++ b/lib/model/hdbscan.js
@@ -1,3 +1,9 @@
+const metrics = {
+	euclid: (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0)),
+	manhattan: (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0),
+	chebyshev: (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i]))),
+}
+
 /**
  * Hierarchical Density-based spatial clustering of applications with noise
  */
@@ -18,17 +24,7 @@ export default class HDBSCAN {
 		if (typeof this._metric === 'function') {
 			this._d = this._metric
 		} else {
-			switch (this._metric) {
-				case 'euclid':
-					this._d = (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0))
-					break
-				case 'manhattan':
-					this._d = (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0)
-					break
-				case 'chebyshev':
-					this._d = (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i])))
-					break
-			}
+			this._d = metrics[this._metric]
 		}
 	}
 

--- a/lib/model/inverse_distance_weighting.js
+++ b/lib/model/inverse_distance_weighting.js
@@ -1,3 +1,16 @@
+const metrics = {
+	euclid: () => (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0)),
+	manhattan: () => (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0),
+	chebyshev: () => (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i]))),
+	minkowski:
+		({ p = 2 } = {}) =>
+		(a, b) =>
+			Math.pow(
+				a.reduce((s, v, i) => s + (v - b[i]) ** p, 0),
+				1 / p
+			),
+}
+
 /**
  * Inverse distance weighting
  */
@@ -17,25 +30,7 @@ export default class InverseDistanceWeighting {
 		if (typeof this._metric === 'function') {
 			this._d = this._metric
 		} else {
-			switch (this._metric) {
-				case 'euclid':
-					this._d = (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0))
-					break
-				case 'manhattan':
-					this._d = (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0)
-					break
-				case 'chebyshev':
-					this._d = (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i])))
-					break
-				case 'minkowski':
-					this._dp = 2
-					this._d = (a, b) =>
-						Math.pow(
-							a.reduce((s, v, i) => s + (v - b[i]) ** this._dp, 0),
-							1 / this._dp
-						)
-					break
-			}
+			this._d = metrics[this._metric]()
 		}
 	}
 

--- a/lib/model/kdeos.js
+++ b/lib/model/kdeos.js
@@ -1,3 +1,8 @@
+const kernels = {
+	gaussian: (u, h, d) => Math.exp(-(u ** 2) / (2 * h ** 2)) / (h * Math.sqrt(2 * Math.PI)) ** d,
+	epanechnikov: (u, h, d) => (3 * (1 - (u / h) ** 2)) / (4 * h ** d),
+}
+
 /**
  * Kernel Density Estimation Outlier Score
  */
@@ -20,11 +25,7 @@ export default class KDEOS {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			if (kernel.name === 'gaussian') {
-				this._kernel = (u, h, d) => Math.exp(-(u ** 2) / (2 * h ** 2)) / (h * Math.sqrt(2 * Math.PI)) ** d
-			} else {
-				this._kernel = (u, h, d) => (3 * (1 - (u / h) ** 2)) / (4 * h ** d)
-			}
+			this._kernel = kernels[kernel.name]
 		}
 	}
 

--- a/lib/model/kernel_density_estimator.js
+++ b/lib/model/kernel_density_estimator.js
@@ -1,3 +1,12 @@
+const kernels = {
+	gaussian: x => Math.exp((-x * x) / 2) / Math.sqrt(2 * Math.PI),
+	rectangular: x => (Math.abs(x) <= 1 ? 0.5 : 0),
+	triangular: x => (Math.abs(x) <= 1 ? 1 - Math.abs(x) : 0),
+	epanechnikov: x => (Math.abs(x) <= 1 ? (3 * (1 - x ** 2)) / 4 : 0),
+	biweight: x => (Math.abs(x) <= 1 ? (15 / 16) * (1 - x ** 2) ** 2 : 0),
+	triweight: x => (Math.abs(x) <= 1 ? (35 / 32) * (1 - x ** 2) ** 3 : 0),
+}
+
 /**
  * Kernel density estimator
  */
@@ -16,26 +25,7 @@ export default class KernelDensityEstimator {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			switch (kernel.name) {
-				case 'gaussian':
-					this._kernel = x => Math.exp((-x * x) / 2) / Math.sqrt(2 * Math.PI)
-					break
-				case 'rectangular':
-					this._kernel = x => (Math.abs(x) <= 1 ? 0.5 : 0)
-					break
-				case 'triangular':
-					this._kernel = x => (Math.abs(x) <= 1 ? 1 - Math.abs(x) : 0)
-					break
-				case 'epanechnikov':
-					this._kernel = x => (Math.abs(x) <= 1 ? (3 * (1 - x ** 2)) / 4 : 0)
-					break
-				case 'biweight':
-					this._kernel = x => (Math.abs(x) <= 1 ? (15 / 16) * (1 - x ** 2) ** 2 : 0)
-					break
-				case 'triweight':
-					this._kernel = x => (Math.abs(x) <= 1 ? (35 / 32) * (1 - x ** 2) ** 3 : 0)
-					break
-			}
+			this._kernel = kernels[kernel.name]
 		}
 	}
 

--- a/lib/model/kernelized_pegasos.js
+++ b/lib/model/kernelized_pegasos.js
@@ -1,3 +1,14 @@
+const kernels = {
+	gaussian:
+		({ s = 1 }) =>
+		(a, b) =>
+			Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / s ** 2),
+	polynomial:
+		({ d = 2 }) =>
+		(a, b) =>
+			(1 + a.reduce((s, v, i) => s + v * b[i])) ** d,
+}
+
 /**
  * Kernelized Primal Estimated sub-GrAdientSOlver for SVM
  */
@@ -18,17 +29,7 @@ export default class KernelizedPegasos {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			switch (kernel.name) {
-				case 'gaussian':
-					this._s = kernel.s ?? 1
-					this._kernel = (a, b) =>
-						Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / this._s ** 2)
-					break
-				case 'polynomial':
-					this._d = kernel.d ?? 2
-					this._kernel = (a, b) => (1 + a.reduce((s, v, i) => s + v * b[i])) ** this._d
-					break
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 	}
 

--- a/lib/model/kernelized_perceptron.js
+++ b/lib/model/kernelized_perceptron.js
@@ -1,3 +1,14 @@
+const kernels = {
+	gaussian:
+		({ s = 1 }) =>
+		(a, b) =>
+			Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / s ** 2),
+	polynomial:
+		({ d = 2 }) =>
+		(a, b) =>
+			(1 + a.reduce((s, v, i) => s + v * b[i])) ** d,
+}
+
 /**
  * Kernelized perceptron
  */
@@ -18,17 +29,7 @@ export default class KernelizedPerceptron {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			switch (kernel.name) {
-				case 'gaussian':
-					this._s = kernel.s ?? 1
-					this._kernel = (a, b) =>
-						Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / this._s ** 2)
-					break
-				case 'polynomial':
-					this._d = kernel.d ?? 2
-					this._kernel = (a, b) => (1 + a.reduce((s, v, i) => s + v * b[i])) ** this._d
-					break
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 
 		this._i = []

--- a/lib/model/knearestneighbor.js
+++ b/lib/model/knearestneighbor.js
@@ -1,3 +1,16 @@
+const metrics = {
+	euclid: () => (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0)),
+	manhattan: () => (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0),
+	chebyshev: () => (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i]))),
+	minkowski:
+		({ p = 2 } = {}) =>
+		(a, b) =>
+			Math.pow(
+				a.reduce((s, v, i) => s + (v - b[i]) ** p, 0),
+				1 / p
+			),
+}
+
 /**
  * Bsae class for k-nearest neighbor models
  */
@@ -15,25 +28,7 @@ class KNNBase {
 		if (typeof this._metric === 'function') {
 			this._d = this._metric
 		} else {
-			switch (this._metric) {
-				case 'euclid':
-					this._d = (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0))
-					break
-				case 'manhattan':
-					this._d = (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0)
-					break
-				case 'chebyshev':
-					this._d = (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i])))
-					break
-				case 'minkowski':
-					this._dp = 2
-					this._d = (a, b) =>
-						Math.pow(
-							a.reduce((s, v, i) => s + (v - b[i]) ** this._dp, 0),
-							1 / this._dp
-						)
-					break
-			}
+			this._d = metrics[this._metric]()
 		}
 	}
 

--- a/lib/model/nearest_centroid.js
+++ b/lib/model/nearest_centroid.js
@@ -1,3 +1,16 @@
+const metrics = {
+	euclid: () => (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0)),
+	manhattan: () => (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0),
+	chebyshev: () => (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i]))),
+	minkowski:
+		({ p = 2 } = {}) =>
+		(a, b) =>
+			Math.pow(
+				a.reduce((s, v, i) => s + (v - b[i]) ** p, 0),
+				1 / p
+			),
+}
+
 /**
  * Nearest centroid classifier
  */
@@ -13,25 +26,7 @@ export default class NearestCentroid {
 		if (typeof this._metric === 'function') {
 			this._d = this._metric
 		} else {
-			switch (this._metric) {
-				case 'euclid':
-					this._d = (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0))
-					break
-				case 'manhattan':
-					this._d = (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0)
-					break
-				case 'chebyshev':
-					this._d = (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i])))
-					break
-				case 'minkowski':
-					this._dp = 2
-					this._d = (a, b) =>
-						Math.pow(
-							a.reduce((s, v, i) => s + (v - b[i]) ** this._dp, 0),
-							1 / this._dp
-						)
-					break
-			}
+			this._d = metrics[this._metric]()
 		}
 	}
 

--- a/lib/model/nnbca.js
+++ b/lib/model/nnbca.js
@@ -1,3 +1,16 @@
+const metrics = {
+	euclid: () => (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0)),
+	manhattan: () => (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0),
+	chebyshev: () => (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i]))),
+	minkowski:
+		({ p = 2 } = {}) =>
+		(a, b) =>
+			Math.pow(
+				a.reduce((s, v, i) => s + (v - b[i]) ** p, 0),
+				1 / p
+			),
+}
+
 /**
  *  Natural Neighborhood Based Classification Algorithm
  */
@@ -12,25 +25,7 @@ export default class NNBCA {
 		if (typeof this._metric === 'function') {
 			this._d = this._metric
 		} else {
-			switch (this._metric) {
-				case 'euclid':
-					this._d = (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0))
-					break
-				case 'manhattan':
-					this._d = (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0)
-					break
-				case 'chebyshev':
-					this._d = (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i])))
-					break
-				case 'minkowski':
-					this._dp = 2
-					this._d = (a, b) =>
-						Math.pow(
-							a.reduce((s, v, i) => s + (v - b[i]) ** this._dp, 0),
-							1 / this._dp
-						)
-					break
-			}
+			this._d = metrics[this._metric]()
 		}
 	}
 

--- a/lib/model/ocsvm.js
+++ b/lib/model/ocsvm.js
@@ -1,6 +1,6 @@
-const Kernel = {
+const kernels = {
 	gaussian:
-		(d = 1) =>
+		({ d = 1 }) =>
 		(a, b) => {
 			let r = a.reduce((acc, v, i) => acc + (v - b[i]) ** 2, 0)
 			return Math.exp(-r / (2 * d * d))
@@ -26,11 +26,7 @@ export default class OCSVM {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			if (kernel.name === 'gaussian') {
-				this._kernel = Kernel.gaussian(kernel.d)
-			} else {
-				this._kernel = Kernel.linear()
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 
 		this._nu = nu

--- a/lib/model/optics.js
+++ b/lib/model/optics.js
@@ -33,6 +33,12 @@ class PriorityQueue {
 	}
 }
 
+const metrics = {
+	euclid: (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0)),
+	manhattan: (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0),
+	chebyshev: (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i]))),
+}
+
 /**
  * Ordering points to identify the clustering structure
  */
@@ -53,17 +59,7 @@ export default class OPTICS {
 		if (typeof this._metric === 'function') {
 			this._d = this._metric
 		} else {
-			switch (this._metric) {
-				case 'euclid':
-					this._d = (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0))
-					break
-				case 'manhattan':
-					this._d = (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0)
-					break
-				case 'chebyshev':
-					this._d = (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i])))
-					break
-			}
+			this._d = metrics[this._metric]
 		}
 	}
 

--- a/lib/model/pca.js
+++ b/lib/model/pca.js
@@ -1,14 +1,14 @@
 import Matrix from '../util/matrix.js'
 
-const Kernel = {
+const kernels = {
 	gaussian:
-		(sigma = 1.0) =>
+		({ sigma = 1.0 }) =>
 		(x, y) => {
 			const s = Matrix.sub(x, y).reduce((acc, v) => acc + v * v, 0)
 			return Math.exp(-s / sigma ** 2)
 		},
 	polynomial:
-		(n = 2) =>
+		({ n = 2 }) =>
 		(x, y) => {
 			return x.dot(y.t).toScaler() ** n
 		},
@@ -113,11 +113,7 @@ export class KernelPCA {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			if (kernel.name === 'gaussian') {
-				this._kernel = Kernel.gaussian(kernel.sigma)
-			} else {
-				this._kernel = Kernel.polynomial(kernel.n)
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 		this._rd = rd ?? 0
 	}

--- a/lib/model/projectron.js
+++ b/lib/model/projectron.js
@@ -1,3 +1,14 @@
+const kernels = {
+	gaussian:
+		({ s = 1 }) =>
+		(a, b) =>
+			Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / s ** 2),
+	polynomial:
+		({ d = 2 }) =>
+		(a, b) =>
+			(1 + a.reduce((s, v, i) => s + v * b[i])) ** d,
+}
+
 /**
  * Projectron
  */
@@ -19,17 +30,7 @@ export class Projectron {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			switch (kernel.name) {
-				case 'gaussian':
-					this._s = kernel.s ?? 1
-					this._kernel = (a, b) =>
-						Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / this._s ** 2)
-					break
-				case 'polynomial':
-					this._d = kernel.d ?? 2
-					this._kernel = (a, b) => (1 + a.reduce((s, v, i) => s + v * b[i])) ** this._d
-					break
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 
 		this._S = []
@@ -139,17 +140,7 @@ export class Projectronpp {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			switch (kernel.name) {
-				case 'gaussian':
-					this._s = kernel.s ?? 1
-					this._kernel = (a, b) =>
-						Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / this._s ** 2)
-					break
-				case 'polynomial':
-					this._d = kernel.d ?? 2
-					this._kernel = (a, b) => (1 + a.reduce((s, v, i) => s + v * b[i])) ** this._d
-					break
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 
 		this._S = []

--- a/lib/model/radius_neighbor.js
+++ b/lib/model/radius_neighbor.js
@@ -1,3 +1,16 @@
+const metrics = {
+	euclid: () => (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0)),
+	manhattan: () => (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0),
+	chebyshev: () => (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i]))),
+	minkowski:
+		({ p = 2 } = {}) =>
+		(a, b) =>
+			Math.pow(
+				a.reduce((s, v, i) => s + (v - b[i]) ** p, 0),
+				1 / p
+			),
+}
+
 /**
  * Bsae class for radius neighbor models
  */
@@ -16,25 +29,7 @@ class RadiusNeighborBase {
 		if (typeof this._metric === 'function') {
 			this._d = this._metric
 		} else {
-			switch (this._metric) {
-				case 'euclid':
-					this._d = (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0))
-					break
-				case 'manhattan':
-					this._d = (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0)
-					break
-				case 'chebyshev':
-					this._d = (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i])))
-					break
-				case 'minkowski':
-					this._dp = 2
-					this._d = (a, b) =>
-						Math.pow(
-							a.reduce((s, v, i) => s + (v - b[i]) ** this._dp, 0),
-							1 / this._dp
-						)
-					break
-			}
+			this._d = metrics[this._metric]()
 		}
 	}
 

--- a/lib/model/rbf.js
+++ b/lib/model/rbf.js
@@ -1,5 +1,24 @@
 import Matrix from '../util/matrix.js'
 
+const rbfs = {
+	linear: () => (x, c) => Math.sqrt(x.reduce((s, v, i) => s + (v - c[i]) ** 2, 0)),
+	gaussian: e => (x, c) => Math.exp(-x.reduce((s, v, i) => s + (v - c[i]) ** 2, 0) * e ** 2),
+	multiquadric: e => (x, c) => Math.sqrt(1 + x.reduce((s, v, i) => s + (v - c[i]) ** 2, 0) * e ** 2),
+	'inverse quadratic': e => (x, c) => 1 / (1 + x.reduce((s, v, i) => s + (v - c[i]) ** 2, 0) * e ** 2),
+	'inverse multiquadric': e => (x, c) => 1 / Math.sqrt(1 + x.reduce((s, v, i) => s + (v - c[i]) ** 2, 0) * e ** 2),
+	'thin plate': () => (x, c) => {
+		const r = x.reduce((s, v, i) => s + (v - c[i]) ** 2, 0)
+		return r === 0 ? 0 : r * Math.log(Math.sqrt(r))
+	},
+	bump: e => (x, c) => {
+		const r = x.reduce((s, v, i) => s + (v - c[i]) ** 2, 0)
+		if (Math.sqrt(r) < 1 / e) {
+			return Math.exp(-1 / (1 - r * e ** 2))
+		}
+		return 0
+	},
+}
+
 /**
  * Radial basis function network
  */
@@ -13,36 +32,9 @@ export default class RadialBasisFunctionNetwork {
 	 * @param {number} [l] Regularization parameter
 	 */
 	constructor(rbf = 'linear', e = 1, l = 0) {
-		const d2 = (x, c) => x.reduce((s, v, i) => s + (v - c[i]) ** 2, 0)
-		if (rbf === 'linear') {
-			this._f = (x, c) => Math.sqrt(d2(x, c))
-			if (l === 0) {
-				l = 1.0e-8
-			}
-		} else if (rbf === 'gaussian') {
-			this._f = (x, c) => Math.exp(-d2(x, c) * e ** 2)
-		} else if (rbf === 'multiquadric') {
-			this._f = (x, c) => Math.sqrt(1 + d2(x, c) * e ** 2)
-		} else if (rbf === 'inverse quadratic') {
-			this._f = (x, c) => 1 / (1 + d2(x, c) * e ** 2)
-		} else if (rbf === 'inverse multiquadric') {
-			this._f = (x, c) => 1 / Math.sqrt(1 + d2(x, c) * e ** 2)
-		} else if (rbf === 'thin plate') {
-			this._f = (x, c) => {
-				const r = d2(x, c)
-				return r === 0 ? 0 : r * Math.log(Math.sqrt(r))
-			}
-			if (l === 0) {
-				l = 1.0e-8
-			}
-		} else if (rbf === 'bump') {
-			this._f = (x, c) => {
-				const r = d2(x, c)
-				if (Math.sqrt(r) < 1 / e) {
-					return Math.exp(-1 / (1 - r * e ** 2))
-				}
-				return 0
-			}
+		this._f = rbfs[rbf](e)
+		if ((rbf === 'linear' || rbf === 'thin plate') && l === 0) {
+			l = 1.0e-8
 		}
 		this._l = l
 	}

--- a/lib/model/rdos.js
+++ b/lib/model/rdos.js
@@ -1,3 +1,7 @@
+const kernels = {
+	gaussian: x => Math.exp(-x.reduce((s, v) => s + v ** 2, 0) / 2) / Math.sqrt(2 * Math.PI) ** x.length,
+}
+
 /**
  * Relative Density-based Outlier Score
  */
@@ -15,7 +19,7 @@ export default class RDOS {
 		if (typeof kernel === 'function') {
 			this._kernel = kernel
 		} else if (kernel === 'gaussian' || kernel.name === 'gaussian') {
-			this._kernel = x => Math.exp(-x.reduce((s, v) => s + v ** 2, 0) / 2) / Math.sqrt(2 * Math.PI) ** x.length
+			this._kernel = kernels.gaussian
 		}
 	}
 

--- a/lib/model/ridge.js
+++ b/lib/model/ridge.js
@@ -110,6 +110,15 @@ export class MulticlassRidge {
 	}
 }
 
+const kernels = {
+	gaussian:
+		({ s = 1.0 }) =>
+		(x, y) => {
+			const k = Matrix.sub(x, y).reduce((acc, v) => acc + v * v, 0)
+			return Math.exp(-k / s ** 2)
+		},
+}
+
 /**
  * Kernel ridge regression
  */
@@ -129,11 +138,7 @@ export class KernelRidge {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			const s = kernel.s ?? 1.0
-			this._kernel = (x, y, sigma = s) => {
-				const s = Matrix.sub(x, y).reduce((acc, v) => acc + v * v, 0)
-				return Math.exp(-s / sigma ** 2)
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 	}
 

--- a/lib/model/rkof.js
+++ b/lib/model/rkof.js
@@ -1,3 +1,17 @@
+const kernels = {
+	gaussian: () => x => Math.exp(-x.reduce((s, v) => s + v ** 2, 0) / 2) / Math.sqrt(2 * Math.PI) ** x.length,
+	epanechnikov: () => x => {
+		const s2 = x.reduce((s, v) => s + v ** 2, 0)
+		return s2 > 1 ? 0 : (3 / 4) ** x.length * (1 - s2)
+	},
+	volcano:
+		({ beta = 1 }) =>
+		x => {
+			const s2 = x.reduce((s, v) => s + v ** 2, 0)
+			return s2 <= 1 ? beta : beta * Math.exp(-s2 + 1)
+		},
+}
+
 /**
  * Robust Kernel-based Outlier Factor
  */
@@ -21,21 +35,7 @@ export default class RKOF {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			if (kernel.name === 'gaussian') {
-				this._kernel = x =>
-					Math.exp(-x.reduce((s, v) => s + v ** 2, 0) / 2) / Math.sqrt(2 * Math.PI) ** x.length
-			} else if (kernel.name === 'epanechnikov') {
-				this._kernel = x => {
-					const s2 = x.reduce((s, v) => s + v ** 2, 0)
-					return s2 > 1 ? 0 : (3 / 4) ** x.length * (1 - s2)
-				}
-			} else if (kernel.name === 'volcano') {
-				this._beta = kernel.beta ?? 1
-				this._kernel = x => {
-					const s2 = x.reduce((s, v) => s + v ** 2, 0)
-					return s2 <= 1 ? this._beta : this._beta * Math.exp(-s2 + 1)
-				}
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 	}
 

--- a/lib/model/s3vm.js
+++ b/lib/model/s3vm.js
@@ -1,8 +1,8 @@
 import Matrix from '../util/matrix.js'
 
-const Kernel = {
+const kernels = {
 	gaussian:
-		(d = 1) =>
+		({ d = 1 }) =>
 		(a, b) => {
 			let r = a.reduce((acc, v, i) => acc + (v - b[i]) ** 2, 0)
 			return Math.exp(-r / (2 * d * d))
@@ -34,11 +34,7 @@ export default class S3VM {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			if (kernel.name === 'gaussian') {
-				this._kernel = Kernel.gaussian(kernel.d)
-			} else {
-				this._kernel = Kernel.linear()
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 	}
 

--- a/lib/model/silk.js
+++ b/lib/model/silk.js
@@ -1,3 +1,14 @@
+const kernels = {
+	gaussian:
+		({ s = 1 }) =>
+		(a, b) =>
+			Math.exp(-a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) / s ** 2),
+	polynomial:
+		({ d = 2 }) =>
+		(a, b) =>
+			(1 + a.reduce((s, v, i) => s + v * b[i], 0)) ** d,
+}
+
 /**
  * Implicit online Learning with Kernels
  */
@@ -21,17 +32,7 @@ export class ILK {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			switch (kernel.name) {
-				case 'gaussian':
-					this._s = kernel.s ?? 1
-					this._kernel = (a, b) =>
-						Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / this._s ** 2)
-					break
-				case 'polynomial':
-					this._d = kernel.d ?? 2
-					this._kernel = (a, b) => (1 + a.reduce((s, v, i) => s + v * b[i])) ** this._d
-					break
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 		if (loss === 'square') {
 			this._loss = (f, k, y) => {

--- a/lib/model/stoptron.js
+++ b/lib/model/stoptron.js
@@ -1,3 +1,14 @@
+const kernels = {
+	gaussian:
+		({ s = 1 }) =>
+		(a, b) =>
+			Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / s ** 2),
+	polynomial:
+		({ d = 2 }) =>
+		(a, b) =>
+			(1 + a.reduce((s, v, i) => s + v * b[i])) ** d,
+}
+
 /**
  * Stoptron
  */
@@ -20,17 +31,7 @@ export default class Stoptron {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			switch (kernel.name) {
-				case 'gaussian':
-					this._s = kernel.s ?? 1
-					this._kernel = (a, b) =>
-						Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / this._s ** 2)
-					break
-				case 'polynomial':
-					this._d = kernel.d ?? 2
-					this._kernel = (a, b) => (1 + a.reduce((s, v, i) => s + v * b[i])) ** this._d
-					break
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 
 		this._i = []

--- a/lib/model/svc.js
+++ b/lib/model/svc.js
@@ -1,6 +1,6 @@
-const Kernel = {
+const kernels = {
 	gaussian:
-		(d = 1) =>
+		({ d = 1 }) =>
 		(a, b) => {
 			const r = a.reduce((acc, v, i) => acc + (v - b[i]) ** 2, 0)
 			return Math.exp(-r / (2 * d * d))
@@ -24,11 +24,7 @@ export default class SVC {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			if (kernel.name === 'gaussian') {
-				this._kernel = Kernel.gaussian(kernel.d)
-			} else {
-				this._kernel = Kernel.linear()
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 
 		this._C = 1

--- a/lib/model/svm.js
+++ b/lib/model/svm.js
@@ -1,6 +1,6 @@
-const Kernel = {
+const kernels = {
 	gaussian:
-		(d = 1) =>
+		({ d = 1 }) =>
 		(a, b) => {
 			let r = a.reduce((acc, v, i) => acc + (v - b[i]) ** 2, 0)
 			return Math.exp(-r / (2 * d * d))
@@ -33,11 +33,7 @@ export default class SVM {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			if (kernel.name === 'gaussian') {
-				this._kernel = Kernel.gaussian(kernel.d)
-			} else {
-				this._kernel = Kernel.linear()
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 	}
 

--- a/lib/model/svr.js
+++ b/lib/model/svr.js
@@ -1,6 +1,6 @@
-const Kernel = {
+const kernels = {
 	gaussian:
-		(d = 1) =>
+		({ d = 1 }) =>
 		(a, b) => {
 			let r = a.reduce((acc, v, i) => acc + (v - b[i]) ** 2, 0)
 			return Math.exp(-r / (2 * d * d))
@@ -23,11 +23,7 @@ export default class SVR {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			if (kernel.name === 'gaussian') {
-				this._kernel = Kernel.gaussian(kernel.d)
-			} else {
-				this._kernel = Kernel.linear()
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 
 		this._C = 1

--- a/lib/model/tightest_perceptron.js
+++ b/lib/model/tightest_perceptron.js
@@ -101,6 +101,17 @@ const regularizedIncompleteBeta = (z, a, b) => {
 	return Math.exp(logIncompleteBeta(z, a, b) - logBeta(a, b))
 }
 
+const kernels = {
+	gaussian:
+		({ s = 1 }) =>
+		(a, b) =>
+			Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / s ** 2),
+	polynomial:
+		({ d = 2 }) =>
+		(a, b) =>
+			(1 + a.reduce((s, v, i) => s + v * b[i], 0)) ** d,
+}
+
 /**
  * Tightest Perceptron
  */
@@ -123,17 +134,7 @@ export default class TightestPerceptron {
 			if (typeof kernel === 'string') {
 				kernel = { name: kernel }
 			}
-			switch (kernel.name) {
-				case 'gaussian':
-					this._s = kernel.s ?? 1
-					this._kernel = (a, b) =>
-						Math.exp(-(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0) ** 2) / this._s ** 2)
-					break
-				case 'polynomial':
-					this._d = kernel.d ?? 2
-					this._kernel = (a, b) => (1 + a.reduce((s, v, i) => s + v * b[i])) ** this._d
-					break
-			}
+			this._kernel = kernels[kernel.name](kernel)
 		}
 
 		if (accuracyLoss === 'hinge') {

--- a/lib/model/weighted_knn.js
+++ b/lib/model/weighted_knn.js
@@ -1,3 +1,27 @@
+const metrics = {
+	euclid: () => (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0)),
+	manhattan: () => (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0),
+	chebyshev: () => (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i]))),
+	minkowski:
+		({ p = 2 } = {}) =>
+		(a, b) =>
+			Math.pow(
+				a.reduce((s, v, i) => s + (v - b[i]) ** p, 0),
+				1 / p
+			),
+}
+
+const weights = {
+	gaussian: d => Math.exp(-(d ** 2) / 2),
+	rectangular: d => (Math.abs(d) > 1 ? 0 : 0.5),
+	triangular: d => (Math.abs(d) > 1 ? 0 : 1 - Math.abs(d)),
+	epanechnikov: d => (Math.abs(d) > 1 ? 0 : (3 / 4) * (1 - d ** 2)),
+	quartic: d => (Math.abs(d) > 1 ? 0 : (15 / 16) * (1 - d ** 2) ** 2),
+	triweight: d => (Math.abs(d) > 1 ? 0 : (35 / 32) * (1 - d ** 2) ** 3),
+	cosine: d => (Math.abs(d) > 1 ? 0 : (Math.PI / 4) * Math.cos((Math.PI / 2) * d)),
+	inversion: d => 1 / Math.abs(d),
+}
+
 /**
  *  Weighted K-Nearest Neighbor
  */
@@ -15,54 +39,11 @@ export default class WeightedKNN {
 		if (typeof this._metric === 'function') {
 			this._d = this._metric
 		} else {
-			switch (this._metric) {
-				case 'euclid':
-					this._d = (a, b) => Math.sqrt(a.reduce((s, v, i) => s + (v - b[i]) ** 2, 0))
-					break
-				case 'manhattan':
-					this._d = (a, b) => a.reduce((s, v, i) => s + Math.abs(v - b[i]), 0)
-					break
-				case 'chebyshev':
-					this._d = (a, b) => Math.max(...a.map((v, i) => Math.abs(v - b[i])))
-					break
-				case 'minkowski':
-					this._dp = 2
-					this._d = (a, b) =>
-						Math.pow(
-							a.reduce((s, v, i) => s + (v - b[i]) ** this._dp, 0),
-							1 / this._dp
-						)
-					break
-			}
+			this._d = metrics[this._metric]()
 		}
 
 		this._weight = weight
-		switch (this._weight) {
-			case 'gaussian':
-				this._w = d => Math.exp(-(d ** 2) / 2)
-				break
-			case 'rectangular':
-				this._w = d => (Math.abs(d) > 1 ? 0 : 0.5)
-				break
-			case 'triangular':
-				this._w = d => (Math.abs(d) > 1 ? 0 : 1 - Math.abs(d))
-				break
-			case 'epanechnikov':
-				this._w = d => (Math.abs(d) > 1 ? 0 : (3 / 4) * (1 - d ** 2))
-				break
-			case 'quartic':
-				this._w = d => (Math.abs(d) > 1 ? 0 : (15 / 16) * (1 - d ** 2) ** 2)
-				break
-			case 'triweight':
-				this._w = d => (Math.abs(d) > 1 ? 0 : (35 / 32) * (1 - d ** 2) ** 3)
-				break
-			case 'cosine':
-				this._w = d => (Math.abs(d) > 1 ? 0 : (Math.PI / 4) * Math.cos((Math.PI / 2) * d))
-				break
-			case 'inversion':
-				this._w = d => 1 / Math.abs(d)
-				break
-		}
+		this._w = weights[this._weight]
 	}
 
 	/**


### PR DESCRIPTION
Resolve #907 .

Changes proposed in this pull request:
- Use object literals instead of switch statements in some constructors