### PR TITLE
Move type-only imports to comments

### DIFF
--- a/create_import_list.js
+++ b/create_import_list.js
@@ -189,8 +189,14 @@ const createLayerlist = async () => {
 	}
 	types.sort((a, b) => (a.type < b.type ? -1 : 1))
 	let typeCode = `
-import Matrix from '../../../util/matrix.js'
-import Tensor from '../../../util/tensor.js'
+/**
+ * @ignore
+ * @typedef {import("../../../util/matrix").default} Matrix
+ * @ignore
+ * @typedef {import("../../../util/tensor").default} Tensor
+ * @ignore
+ * @typedef {import("../../neuralnetwork").default} NeuralNetwork
+ */
 /**
  * @typedef {(
 `

--- a/lib/model/nns/layer/index.js
+++ b/lib/model/nns/layer/index.js
@@ -102,8 +102,14 @@ export { default as TransposeLayer } from './transpose.js'
 export { default as VariableLayer } from './variable.js'
 export { default as VarLayer } from './variance.js'
 
-import Matrix from '../../../util/matrix.js'
-import Tensor from '../../../util/tensor.js'
+/**
+ * @ignore
+ * @typedef {import("../../../util/matrix").default} Matrix
+ * @ignore
+ * @typedef {import("../../../util/tensor").default} Tensor
+ * @ignore
+ * @typedef {import("../../neuralnetwork").default} NeuralNetwork
+ */
 /**
  * @typedef {(
  * { type: 'abs' } |


### PR DESCRIPTION
Resolve #923 .

Changes proposed in this pull request:
- Move type-only imports to comments
