### PR TITLE
Fix return type of MulticlassRidge importance method

### DIFF
--- a/lib/model/ridge.js
+++ b/lib/model/ridge.js
@@ -103,7 +103,7 @@ export class MulticlassRidge {
 
 	/**
 	 * Returns importances of the features.
-	 * @returns {number[]} Importances
+	 * @returns {number[][]} Importances
 	 */
 	importance() {
 		return this._w.toArray()


### PR DESCRIPTION
Resolve #985 .

Changes proposed in this pull request:
- Fix return type of MulticlassRidge importance method
