### PR TITLE
Update PELT reference year from 2024 to 2011 in pelt.js

### DIFF
--- a/js/view/pelt.js
+++ b/js/view/pelt.js
@@ -6,7 +6,7 @@ export default function (platform) {
 	platform.setting.ml.reference = {
 		author: 'R. Killick, P. Fearnhead, I. A. Eckley',
 		title: 'Optimal detection of changepoints with a linear computational cost',
-		year: 2024,
+		year: 2011,
 	}
 	const controller = new Controller(platform)
 	const calcSST = function () {


### PR DESCRIPTION
Resolve #995 .

Changes proposed in this pull request:
- Update PELT reference year from 2024 to 2011 in pelt.js
